### PR TITLE
Upgrade Stratocumulus to v0.1.5

### DIFF
--- a/docker/chromap/0.1.5/Dockerfile
+++ b/docker/chromap/0.1.5/Dockerfile
@@ -2,16 +2,14 @@ FROM debian:buster-slim
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update && \
-    apt-get install -y wget build-essential curl unzip wget zlib1g-dev python3 python3-pip && \
-    apt-get install --no-install-recommends -y lsb-release gnupg && \
-    export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-    echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update && apt-get install -y google-cloud-sdk=357.0.0-0 && \
+    apt-get install -y wget build-essential curl unzip wget zlib1g-dev python3 python3-pip gnupg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+    apt-get update && apt-get install -y google-cloud-cli=378.0.0-0 && \
     apt-get -qq -y autoremove && \
     apt-get clean
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.39.zip" -o "awscliv2.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.27.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm awscliv2.zip
@@ -19,7 +17,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.39.zip" -o "a
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN python -m pip install --upgrade pip --no-cache-dir && \
-    python -m pip install stratocumulus==0.1.3 --no-cache-dir
+    python -m pip install stratocumulus==0.1.5 --no-cache-dir
 
 RUN mkdir /software && \
     wget https://github.com/haowenz/chromap/archive/refs/tags/v0.1.5.zip && \
@@ -33,7 +31,7 @@ RUN apt-get -qq -y remove curl gnupg unzip wget && \
     apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
- 
+
 ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
 RUN chmod a+rx /software/monitor_script.sh
 

--- a/docker/cumulus_feature_barcoding/0.7.0/Dockerfile
+++ b/docker/cumulus_feature_barcoding/0.7.0/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get -qq update && \
         libboost-iostreams-dev
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
-    apt-get update -y && apt-get install -y google-cloud-sdk=372.0.0-0
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update -y && apt-get install -y google-cloud-cli=378.0.0-0
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.18.zip" -o "awscliv2.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.27.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm awscliv2.zip
@@ -30,7 +30,7 @@ RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install numpy==1.21.5 --no-cache-dir && \
     python -m pip install pandas==1.3.5 --no-cache-dir && \
     python -m pip install matplotlib==3.5.1 --no-cache-dir && \
-    python -m pip install stratocumulus==0.1.4 --no-cache-dir
+    python -m pip install stratocumulus==0.1.5 --no-cache-dir
 
 RUN tar -xzf /software/0.7.0.tar.gz -C /software && \
     cd /software/cumulus_feature_barcoding-0.7.0 && make clean && make all && cd ../.. && \

--- a/docker/demultiplexing/demuxem/0.1.7/Dockerfile
+++ b/docker/demultiplexing/demuxem/0.1.7/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get -qq update && \
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
-    apt-get update -y && apt-get install -y google-cloud-sdk=357.0.0-0
+    apt-get update -y && apt-get install -y google-cloud-cli=378.0.0-0
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.2.39.zip" -o "awscliv2.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.27.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm awscliv2.zip
@@ -40,7 +40,7 @@ RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install zarr==2.8.3 --no-cache-dir && \
     python -m pip install pegasusio==0.3.1.post2 --no-cache-dir && \
     python -m pip install demuxEM==0.1.7 --no-cache-dir && \
-    python -m pip install stratocumulus==0.1.2 --no-cache-dir
+    python -m pip install stratocumulus==0.1.5 --no-cache-dir
 
 RUN apt-get -qq -y remove curl gnupg && \
     apt-get -qq -y autoremove && \

--- a/docker/starsolo/2.7.10a/Dockerfile
+++ b/docker/starsolo/2.7.10a/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get -qq update && \
@@ -13,24 +13,24 @@ RUN apt-get -qq update && \
         python3-pip
 
 RUN pip3 install --upgrade pip --no-cache-dir && \
-    pip3 install numpy==1.21.5 --no-cache-dir && \
-    pip3 install pandas==1.3.5 --no-cache-dir && \
-    pip3 install stratocumulus==0.1.3 --no-cache-dir
+    pip3 install numpy==1.22.3 --no-cache-dir && \
+    pip3 install pandas==1.4.1 --no-cache-dir && \
+    pip3 install stratocumulus==0.1.5 --no-cache-dir
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
-    apt-get update -y && apt-get install -y google-cloud-sdk=370.0.0-0
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update -y && apt-get install -y google-cloud-cli=378.0.0-0
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.13.zip" -o "awscliv2.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.27.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm awscliv2.zip
 
-RUN wget https://github.com/alexdobin/STAR/archive/refs/tags/2.7.10a_alpha_220207.tar.gz && \
-    tar -xzvf 2.7.10a_alpha_220207.tar.gz && \
-    rm 2.7.10a_alpha_220207.tar.gz && \
+RUN wget https://github.com/alexdobin/STAR/archive/refs/tags/2.7.10a_alpha_220314.tar.gz && \
+    tar -xzvf 2.7.10a_alpha_220314.tar.gz && \
+    rm 2.7.10a_alpha_220314.tar.gz && \
     mkdir /software && \
-    mv STAR-2.7.10a_alpha_220207 /software/STAR && \
+    mv STAR-2.7.10a_alpha_220314 /software/STAR && \
     cd /software/STAR/source && \
     make STAR && \
     mkdir -p /software/STAR/bin && \

--- a/docker/starsolo/2.7.9a/Dockerfile
+++ b/docker/starsolo/2.7.9a/Dockerfile
@@ -14,13 +14,13 @@ RUN apt-get -qq update && \
 RUN pip3 install --upgrade pip --no-cache-dir && \
     pip3 install numpy==1.21.5 --no-cache-dir && \
     pip3 install pandas==1.3.5 --no-cache-dir && \
-    pip3 install stratocumulus==0.1.3 --no-cache-dir
+    pip3 install stratocumulus==0.1.5 --no-cache-dir
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
-    apt-get update -y && apt-get install -y google-cloud-sdk=367.0.0-0
+    apt-get update -y && apt-get install -y google-cloud-cli=378.0.0-0
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.7.zip" -o "awscliv2.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.27.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm awscliv2.zip


### PR DESCRIPTION
Only Stratocumulus v0.1.5 works well with AWS backend for copy commands using wildcards.