### PR TITLE
Add awsQueueArn input

### DIFF
--- a/workflows/cellranger/cellranger_arc_count.wdl
+++ b/workflows/cellranger/cellranger_arc_count.wdl
@@ -53,6 +53,8 @@ workflow cellranger_arc_count {
         Int preemptible = 2
         # Max number of retries for AWS instance
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Backend
         String backend = "gcp"
     }
@@ -84,6 +86,7 @@ workflow cellranger_arc_count {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -115,6 +118,7 @@ task run_cellranger_arc_count {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -186,5 +190,6 @@ task run_cellranger_arc_count {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/cellranger/cellranger_arc_mkfastq.wdl
+++ b/workflows/cellranger/cellranger_arc_mkfastq.wdl
@@ -37,6 +37,8 @@ workflow cellranger_arc_mkfastq {
         Int preemptible = 2
         # Max number of retries for AWS instance
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Backend
         String backend = "gcp"
     }
@@ -59,6 +61,7 @@ workflow cellranger_arc_mkfastq {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -87,6 +90,7 @@ task run_cellranger_arc_mkfastq {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -167,5 +171,6 @@ task run_cellranger_arc_mkfastq {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/cellranger/cellranger_atac_mkfastq.wdl
+++ b/workflows/cellranger/cellranger_atac_mkfastq.wdl
@@ -37,6 +37,8 @@ workflow cellranger_atac_mkfastq {
         Int preemptible = 2
         # Max number of retries for AWS instance
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Backend
         String backend = "gcp"
     }
@@ -59,6 +61,7 @@ workflow cellranger_atac_mkfastq {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -87,6 +90,7 @@ task run_cellranger_atac_mkfastq {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -166,5 +170,6 @@ task run_cellranger_atac_mkfastq {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/cellranger/cellranger_count.wdl
+++ b/workflows/cellranger/cellranger_count.wdl
@@ -53,6 +53,8 @@ workflow cellranger_count {
         Int preemptible = 2
         # Max number of retries for AWS instance
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Backend
         String backend = "gcp"
     }
@@ -87,6 +89,7 @@ workflow cellranger_count {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -122,6 +125,7 @@ task run_cellranger_count {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -270,5 +274,6 @@ task run_cellranger_count {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/cellranger/cellranger_mkfastq.wdl
+++ b/workflows/cellranger/cellranger_mkfastq.wdl
@@ -37,6 +37,8 @@ workflow cellranger_mkfastq {
         Int preemptible = 2
         # Max number of retries for AWS instance
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Backend
         String backend = "gcp"
     }
@@ -59,6 +61,7 @@ workflow cellranger_mkfastq {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -87,6 +90,7 @@ task run_cellranger_mkfastq {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -167,5 +171,6 @@ task run_cellranger_mkfastq {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/cellranger/cellranger_multi.wdl
+++ b/workflows/cellranger/cellranger_multi.wdl
@@ -52,6 +52,8 @@ workflow cellranger_multi {
         Int preemptible = 2
         # Max number of retries for AWS instance
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Backend
         String backend = "gcp"
     }
@@ -85,6 +87,7 @@ workflow cellranger_multi {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -116,6 +119,7 @@ task run_cellranger_multi {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -245,5 +249,6 @@ task run_cellranger_multi {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/cellranger/cellranger_vdj.wdl
+++ b/workflows/cellranger/cellranger_vdj.wdl
@@ -12,7 +12,7 @@ workflow cellranger_vdj {
         # GRCh38_vdj, GRCm38_vdj or a URL to a tar.gz file
         String genome
 
-        # Index TSV file    
+        # Index TSV file
         File acronym_file
 
         # Do not align reads to reference V(D)J sequences before de novo assembly. Default: false
@@ -42,6 +42,8 @@ workflow cellranger_vdj {
         Int preemptible = 2
         # Max number of retries for AWS instance
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Backend
         String backend = "gcp"
     }
@@ -68,6 +70,7 @@ workflow cellranger_vdj {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -95,6 +98,7 @@ task run_cellranger_vdj {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -155,5 +159,6 @@ task run_cellranger_vdj {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -150,6 +150,8 @@ workflow cellranger_workflow {
         Int preemptible = 2
         # Max number of retries for AWS instance
         Int awsMaxRetries = 5
+        # Arn string of AWS queue to use
+        String awsQueueArn = ""
     }
 
     # Output directory, with trailing slashes stripped
@@ -193,8 +195,9 @@ workflow cellranger_workflow {
                         memory = memory,
                         disk_space = mkfastq_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
-                        backend = backend
+                        awsMaxRetries = 0,
+                        backend = backend,
+                        awsQueueArn = awsQueueArn
                 }
             }
         }
@@ -219,8 +222,9 @@ workflow cellranger_workflow {
                         memory = memory,
                         disk_space = mkfastq_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
-                        backend = backend
+                        awsMaxRetries = 0,
+                        backend = backend,
+                        awsQueueArn = awsQueueArn
                 }
             }
         }
@@ -245,8 +249,9 @@ workflow cellranger_workflow {
                         memory = memory,
                         disk_space = mkfastq_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
-                        backend = backend
+                        awsMaxRetries = 0,
+                        backend = backend,
+                        awsQueueArn = awsQueueArn
                 }
             }
         }
@@ -292,8 +297,9 @@ workflow cellranger_workflow {
                         memory = memory,
                         disk_space = count_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
-                        backend = backend
+                        awsMaxRetries = 0,
+                        backend = backend,
+                        awsQueueArn = awsQueueArn
                 }
             }
 
@@ -328,8 +334,9 @@ workflow cellranger_workflow {
                         memory = memory,
                         disk_space = vdj_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
-                        backend = backend
+                        awsMaxRetries = 0,
+                        backend = backend,
+                        awsQueueArn = awsQueueArn
                 }
             }
 
@@ -367,8 +374,9 @@ workflow cellranger_workflow {
                         memory = feature_memory,
                         disk_space = feature_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
-                        backend = backend
+                        awsMaxRetries = 0,
+                        backend = backend,
+                        awsQueueArn = awsQueueArn
                 }
             }
         }
@@ -392,8 +400,9 @@ workflow cellranger_workflow {
                         memory = atac_memory,
                         disk_space = atac_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
-                        backend = backend
+                        awsMaxRetries = 0,
+                        backend = backend,
+                        awsQueueArn = awsQueueArn
                 }
             }
 
@@ -433,8 +442,9 @@ workflow cellranger_workflow {
                         memory = arc_memory,
                         disk_space = arc_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
-                        backend = backend
+                        awsMaxRetries = 0,
+                        backend = backend,
+                        awsQueueArn = awsQueueArn
                 }
             }
 
@@ -476,8 +486,9 @@ workflow cellranger_workflow {
                         memory = memory,
                         disk_space = count_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
-                        backend = backend
+                        awsMaxRetries = 0,
+                        backend = backend,
+                        awsQueueArn = awsQueueArn
                 }
             }
         }
@@ -506,8 +517,9 @@ workflow cellranger_workflow {
                         memory = memory,
                         disk_space = count_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
-                        backend = backend
+                        awsMaxRetries = 0,
+                        backend = backend,
+                        awsQueueArn = awsQueueArn
                 }
             }
 
@@ -526,7 +538,7 @@ workflow cellranger_workflow {
     }
 
     output {
-        Array[Array[String]?] fastq_outputs = [cellranger_mkfastq.output_fastqs_flowcell_directory, cellranger_atac_mkfastq.output_fastqs_flowcell_directory, cellranger_arc_mkfastq.output_fastqs_flowcell_directory]        
+        Array[Array[String]?] fastq_outputs = [cellranger_mkfastq.output_fastqs_flowcell_directory, cellranger_atac_mkfastq.output_fastqs_flowcell_directory, cellranger_arc_mkfastq.output_fastqs_flowcell_directory]
         Map[String, Array[String]?] count_outputs = {"gex": cellranger_count.output_count_directory,
                                                      "vdj": cellranger_vdj.output_vdj_directory,
                                                      "adt": cumulus_adt.output_count_directory,

--- a/workflows/cumulus/cumulus_adt.wdl
+++ b/workflows/cumulus/cumulus_adt.wdl
@@ -47,6 +47,8 @@ workflow cumulus_adt {
         Int preemptible = 2
         # Number of maximum retries when running on AWS
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Backend
         String backend = "gcp"
     }
@@ -75,6 +77,7 @@ workflow cumulus_adt {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -104,6 +107,7 @@ task run_generate_count_matrix_ADTs {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -138,7 +142,7 @@ task run_generate_count_matrix_ADTs {
                 check_call(call_args)
             fastqs.append(target)
 
-        
+
         # GUNZIP cell barcode file if necessary
         cell_barcodes_file = '~{cell_barcodes}'
         if cell_barcodes_file.endswith('.gz'):
@@ -207,5 +211,6 @@ task run_generate_count_matrix_ADTs {
         cpu: 1
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/demultiplexing/demultiplexing.wdl
+++ b/workflows/demultiplexing/demultiplexing.wdl
@@ -23,6 +23,8 @@ workflow demultiplexing {
         Int preemptible = 2
         # Number of maximum retries when running on AWS
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Google cloud zones, default to "us-central1-a us-central1-b us-central1-c us-central1-f us-east1-b us-east1-c us-east1-d us-west1-a us-west1-b us-west1-c"
         String zones = "us-central1-a us-central1-b us-central1-c us-central1-f us-east1-b us-east1-c us-east1-d us-west1-a us-west1-b us-west1-c"
         # Backend
@@ -138,7 +140,8 @@ workflow demultiplexing {
                     memory = demuxEM_memory,
                     disk_space = demuxEM_disk_space,
                     preemptible = preemptible,
-                    awsMaxRetries = awsMaxRetries,
+                    awsMaxRetries = 0,
+                    awsQueueArn = awsQueueArn,
                     backend = backend
             }
         }
@@ -171,7 +174,8 @@ workflow demultiplexing {
                         memory = souporcell_memory,
                         zones = zones,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
+                        awsMaxRetries = 0,
+                        awsQueueArn = awsQueueArn,
                         backend = backend
                 }
             }
@@ -200,7 +204,8 @@ workflow demultiplexing {
                         memory = popscle_memory,
                         zones = zones,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
+                        awsMaxRetries = 0,
+                        awsQueueArn = awsQueueArn,
                         backend = backend
                 }
             }

--- a/workflows/demultiplexing/demuxEM.wdl
+++ b/workflows/demultiplexing/demuxEM.wdl
@@ -42,6 +42,8 @@ workflow demuxEM {
         Int preemptible
         # Number of maximum retries when running on AWS
         Int awsMaxRetries
+        # Arn string of AWS queue
+        String awsQueueArn
         # Backend
         String backend
     }
@@ -68,6 +70,7 @@ workflow demuxEM {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -101,6 +104,7 @@ task run_demuxEM {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -152,5 +156,6 @@ task run_demuxEM {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/demultiplexing/popscle.wdl
+++ b/workflows/demultiplexing/popscle.wdl
@@ -53,6 +53,8 @@ workflow popscle {
         Int preemptible
         # Number of maximum retries when running on AWS
         Int awsMaxRetries
+        # Arn string of AWS queue
+        String awsQueueArn
         # Backend
         String backend
     }
@@ -82,6 +84,7 @@ workflow popscle {
             zones = zones,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -118,6 +121,7 @@ task popscle_task {
         String zones
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -198,5 +202,6 @@ task popscle_task {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsMaxRetries
     }
 }

--- a/workflows/demultiplexing/souporcell.wdl
+++ b/workflows/demultiplexing/souporcell.wdl
@@ -42,6 +42,8 @@ workflow souporcell {
         Int preemptible
         # Number of maximum retries when running on AWS
         Int awsMaxRetries
+        # Arn string of AWS queue
+        String awsQueueArn
         # Backend
         String backend
     }
@@ -71,6 +73,7 @@ workflow souporcell {
             memory = memory,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -90,6 +93,7 @@ workflow souporcell {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -123,6 +127,7 @@ task run_souporcell {
         String memory
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -191,6 +196,7 @@ task run_souporcell {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }
 
@@ -211,6 +217,7 @@ task match_donors {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -259,5 +266,6 @@ task match_donors {
         disks: "local-disk ~{disk_space} HDD"
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/spaceranger/spaceranger_mkfastq.wdl
+++ b/workflows/spaceranger/spaceranger_mkfastq.wdl
@@ -31,6 +31,8 @@ workflow spaceranger_mkfastq {
         Int preemptible = 2
         # Number of maximum retries when running on AWS
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Backend
         String backend
     }
@@ -50,6 +52,7 @@ workflow spaceranger_mkfastq {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -75,6 +78,7 @@ task run_spaceranger_mkfastq {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -153,5 +157,6 @@ task run_spaceranger_mkfastq {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/spaceranger/spaceranger_workflow.wdl
+++ b/workflows/spaceranger/spaceranger_workflow.wdl
@@ -57,6 +57,8 @@ workflow spaceranger_workflow {
         Int preemptible = 2
         # Number of maximum retries when running on AWS
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # Backend
         String backend = "gcp"
     }
@@ -99,7 +101,8 @@ workflow spaceranger_workflow {
                         memory = memory,
                         disk_space = mkfastq_disk_space,
                         preemptible = preemptible,
-                        awsMaxRetries = awsMaxRetries,
+                        awsMaxRetries = 0,
+                        awsQueueArn = awsQueueArn,
                         backend = backend
                 }
             }
@@ -147,7 +150,8 @@ workflow spaceranger_workflow {
                     memory = memory,
                     disk_space = count_disk_space,
                     preemptible = preemptible,
-                    awsMaxRetries = awsMaxRetries,
+                    awsMaxRetries = 0,
+                    awsQueueArn = awsQueueArn,
                     backend = backend
             }
         }

--- a/workflows/starsolo/starsolo_count.wdl
+++ b/workflows/starsolo/starsolo_count.wdl
@@ -44,6 +44,7 @@ workflow starsolo_count {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -93,6 +94,7 @@ workflow starsolo_count {
             disk_space = disk_space,
             preemptible = preemptible,
             awsMaxRetries = awsMaxRetries,
+            awsQueueArn = awsQueueArn,
             backend = backend
     }
 
@@ -144,6 +146,7 @@ task run_starsolo {
         Int disk_space
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -361,5 +364,6 @@ task run_starsolo {
         cpu: num_cpu
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }

--- a/workflows/starsolo/starsolo_workflow.wdl
+++ b/workflows/starsolo/starsolo_workflow.wdl
@@ -80,6 +80,8 @@ workflow starsolo_workflow {
         Int preemptible = 2
         # Number of maximum retries when running on AWS
         Int awsMaxRetries = 5
+        # Arn string of AWS queue
+        String awsQueueArn = ""
         # backend choose from "gcp", "aws", "local"
         String backend = "gcp"
     }
@@ -141,7 +143,8 @@ workflow starsolo_workflow {
                     memory = memory,
                     disk_space = disk_space,
                     preemptible = preemptible,
-                    awsMaxRetries = awsMaxRetries,
+                    awsMaxRetries = 0,
+                    awsQueueArn = awsQueueArn,
                     backend = backend
             }
         }
@@ -162,6 +165,7 @@ task generate_count_config {
         String docker_registry
         Int preemptible
         Int awsMaxRetries
+        String awsQueueArn
         String backend
     }
 
@@ -231,5 +235,6 @@ task generate_count_config {
         zones: zones
         preemptible: preemptible
         maxRetries: if backend == "aws" then awsMaxRetries else 0
+        queueArn: awsQueueArn
     }
 }


### PR DESCRIPTION
* `awsQueueArn` is the input to specify the Arn string of the priority queue to use in AWS backend.