### PR TITLE
Add 'mkfastq_force_single_index' input to cellranger_workflow

### DIFF
--- a/docs/cellranger/feature_barcoding.rst
+++ b/docs/cellranger/feature_barcoding.rst
@@ -154,6 +154,10 @@ For feature barcoding data, ``cellranger_workflow`` takes Illumina outputs as in
 		  - Number of mismatches allowed in matching barcode indices (bcl2fastq2 default is 1)
 		  - 0
 		  -
+		* - mkfastq_force_single_index
+		  - If 10x-supplied i7/i5 paired indices are specified, but the flowcell was run with only one sample index, allow the demultiplex to proceed using the i7 half of the sample index pair
+		  - false
+		  - false
 		* - mkfastq_filter_single_index
 		  - Only demultiplex samples identified by an i7-only sample index, ignoring dual-indexed samples. Dual-indexed samples will not be demultiplexed
 		  - false

--- a/docs/cellranger/sc_atac.rst
+++ b/docs/cellranger/sc_atac.rst
@@ -102,6 +102,10 @@ Workflow input
 	  - Number of mismatches allowed in matching barcode indices (bcl2fastq2 default is 1)
 	  - 0
 	  -
+	* - mkfastq_force_single_index
+	  - If 10x-supplied i7/i5 paired indices are specified, but the flowcell was run with only one sample index, allow the demultiplex to proceed using the i7 half of the sample index pair
+	  - false
+	  - false
 	* - mkfastq_filter_single_index
 	  - Only demultiplex samples identified by an i7-only sample index, ignoring dual-indexed samples. Dual-indexed samples will not be demultiplexed
 	  - false

--- a/docs/cellranger/sc_multiomics.rst
+++ b/docs/cellranger/sc_multiomics.rst
@@ -90,6 +90,10 @@ For single-cell multiomics data, ``cellranger_workflow`` takes Illumina outputs 
 	  - Number of mismatches allowed in matching barcode indices (bcl2fastq2 default is 1)
 	  - 0
 	  -
+	* - mkfastq_force_single_index
+	  - If 10x-supplied i7/i5 paired indices are specified, but the flowcell was run with only one sample index, allow the demultiplex to proceed using the i7 half of the sample index pair
+	  - false
+	  - false
 	* - mkfastq_filter_single_index
 	  - Only demultiplex samples identified by an i7-only sample index, ignoring dual-indexed samples. Dual-indexed samples will not be demultiplexed
 	  - false

--- a/docs/cellranger/sc_sn_rnaseq.rst
+++ b/docs/cellranger/sc_sn_rnaseq.rst
@@ -144,6 +144,10 @@ For sc/snRNA-seq data, ``cellranger_workflow`` takes Illumina outputs as input a
 		  - Number of mismatches allowed in matching barcode indices (bcl2fastq2 default is 1)
 		  - 0
 		  -
+		* - mkfastq_force_single_index
+		  - If 10x-supplied i7/i5 paired indices are specified, but the flowcell was run with only one sample index, allow the demultiplex to proceed using the i7 half of the sample index pair
+		  - false
+		  - false
 		* - mkfastq_filter_single_index
 		  - Only demultiplex samples identified by an i7-only sample index, ignoring dual-indexed samples. Dual-indexed samples will not be demultiplexed
 		  - false

--- a/docs/cellranger/sc_vdj.rst
+++ b/docs/cellranger/sc_vdj.rst
@@ -88,6 +88,10 @@ For scIR-seq data, ``cellranger_workflow`` takes Illumina outputs as input and r
 	  - Number of mismatches allowed in matching barcode indices (bcl2fastq2 default is 1)
 	  - 0
 	  -
+	* - mkfastq_force_single_index
+	  - If 10x-supplied i7/i5 paired indices are specified, but the flowcell was run with only one sample index, allow the demultiplex to proceed using the i7 half of the sample index pair
+	  - false
+	  - false
 	* - mkfastq_filter_single_index
 	  - Only demultiplex samples identified by an i7-only sample index, ignoring dual-indexed samples. Dual-indexed samples will not be demultiplexed
 	  - false

--- a/workflows/cellranger/cellranger_arc_mkfastq.wdl
+++ b/workflows/cellranger/cellranger_arc_mkfastq.wdl
@@ -13,6 +13,8 @@ workflow cellranger_arc_mkfastq {
         Boolean delete_input_bcl_directory = false
         # Number of allowed mismatches per index
         Int? barcode_mismatches
+        # If 10x-supplied i7/i5 paired indices are specified, but the flowcell was run with only one sample index, allow the demultiplex to proceed using the i7 half of the sample index pair.
+        Boolean force_single_index = false
         # Only demultiplex samples identified by an i7-only sample index, ignoring dual-indexed samples. Dual-indexed samples will not be demultiplexed.
         Boolean filter_single_index = false
         # Override the read lengths as specified in RunInfo.xml
@@ -50,6 +52,7 @@ workflow cellranger_arc_mkfastq {
             output_directory = sub(output_directory, "/+$", ""),
             delete_input_bcl_directory = delete_input_bcl_directory,
             barcode_mismatches = barcode_mismatches,
+            force_single_index = force_single_index,
             filter_single_index = filter_single_index,
             use_bases_mask = use_bases_mask,
             delete_undetermined = delete_undetermined,
@@ -79,6 +82,7 @@ task run_cellranger_arc_mkfastq {
         String output_directory
         Boolean delete_input_bcl_directory
         Int? barcode_mismatches
+        Boolean force_single_index
         Boolean filter_single_index
         String? use_bases_mask
         Boolean delete_undetermined
@@ -113,6 +117,8 @@ task run_cellranger_arc_mkfastq {
         barcode_mismatches = '~{barcode_mismatches}'
         if barcode_mismatches != '':
             mkfastq_args += ['--barcode-mismatches', barcode_mismatches]
+        if '~{force_single_index}' == 'true':
+            mkfastq_args.append('--force-single-index')
         if '~{filter_single_index}' == 'true':
             mkfastq_args.append('--filter-single-index')
         if '~{use_bases_mask}' != '':

--- a/workflows/cellranger/cellranger_atac_mkfastq.wdl
+++ b/workflows/cellranger/cellranger_atac_mkfastq.wdl
@@ -13,6 +13,8 @@ workflow cellranger_atac_mkfastq {
         Boolean delete_input_bcl_directory = false
         # Number of allowed mismatches per index
         Int? barcode_mismatches
+        # If 10x-supplied i7/i5 paired indices are specified, but the flowcell was run with only one sample index, allow the demultiplex to proceed using the i7 half of the sample index pair.
+        Boolean force_single_index = false
         # Only demultiplex samples identified by an i7-only sample index, ignoring dual-indexed samples. Dual-indexed samples will not be demultiplexed.
         Boolean filter_single_index = false
         # Override the read lengths as specified in RunInfo.xml
@@ -50,6 +52,7 @@ workflow cellranger_atac_mkfastq {
             output_directory = sub(output_directory, "/+$", ""),
             delete_input_bcl_directory = delete_input_bcl_directory,
             barcode_mismatches = barcode_mismatches,
+            force_single_index = force_single_index,
             filter_single_index = filter_single_index,
             use_bases_mask = use_bases_mask,
             delete_undetermined = delete_undetermined,
@@ -79,6 +82,7 @@ task run_cellranger_atac_mkfastq {
         String output_directory
         Boolean delete_input_bcl_directory
         Int? barcode_mismatches
+        Boolean force_single_index
         Boolean filter_single_index
         String? use_bases_mask
         Boolean delete_undetermined
@@ -113,6 +117,8 @@ task run_cellranger_atac_mkfastq {
         barcode_mismatches = '~{barcode_mismatches}'
         if barcode_mismatches != '':
             mkfastq_args += ['--barcode-mismatches', barcode_mismatches]
+        if '~{force_single_index}' == 'true':
+            mkfastq_args.append('--force-single-index')
         if '~{filter_single_index}' == 'true':
             mkfastq_args.append('--filter-single-index')
         if '~{use_bases_mask}' != '':

--- a/workflows/cellranger/cellranger_mkfastq.wdl
+++ b/workflows/cellranger/cellranger_mkfastq.wdl
@@ -13,6 +13,8 @@ workflow cellranger_mkfastq {
         Boolean delete_input_bcl_directory = false
         # Number of allowed mismatches per index
         Int? barcode_mismatches
+        # If 10x-supplied i7/i5 paired indices are specified, but the flowcell was run with only one sample index, allow the demultiplex to proceed using the i7 half of the sample index pair.
+        Boolean force_single_index = false
         # Only demultiplex samples identified by an i7-only sample index, ignoring dual-indexed samples. Dual-indexed samples will not be demultiplexed.
         Boolean filter_single_index = false
         # Override the read lengths as specified in RunInfo.xml
@@ -50,6 +52,7 @@ workflow cellranger_mkfastq {
             output_directory = sub(output_directory, "/+$", ""),
             delete_input_bcl_directory = delete_input_bcl_directory,
             barcode_mismatches = barcode_mismatches,
+            force_single_index = force_single_index,
             filter_single_index = filter_single_index,
             use_bases_mask = use_bases_mask,
             delete_undetermined = delete_undetermined,
@@ -79,6 +82,7 @@ task run_cellranger_mkfastq {
         String output_directory
         Boolean delete_input_bcl_directory
         Int? barcode_mismatches
+        Boolean force_single_index
         Boolean filter_single_index
         String? use_bases_mask
         Boolean delete_undetermined
@@ -113,6 +117,8 @@ task run_cellranger_mkfastq {
         barcode_mismatches = '~{barcode_mismatches}'
         if barcode_mismatches != '':
             mkfastq_args += ['--barcode-mismatches', barcode_mismatches]
+        if '~{force_single_index}' == 'true':
+            mkfastq_args.append('--force-single-index')
         if '~{filter_single_index}' == 'true':
             mkfastq_args.append('--filter-single-index')
         if '~{use_bases_mask}' != '':

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -28,6 +28,8 @@ workflow cellranger_workflow {
         Boolean delete_input_bcl_directory = false
         # Number of allowed mismatches per index
         Int? mkfastq_barcode_mismatches
+        # If 10x-supplied i7/i5 paired indices are specified, but the flowcell was run with only one sample index, allow the demultiplex to proceed using the i7 half of the sample index pair.
+        Boolean mkfastq_force_single_index = false
         # Only demultiplex samples identified by an i7-only sample index, ignoring dual-indexed samples.  Dual-indexed samples will not be demultiplexed.
         Boolean mkfastq_filter_single_index = false
         # Override the read lengths as specified in RunInfo.xml
@@ -185,6 +187,7 @@ workflow cellranger_workflow {
                         output_directory = output_directory_stripped,
                         delete_input_bcl_directory = delete_input_bcl_directory,
                         barcode_mismatches = mkfastq_barcode_mismatches,
+                        force_single_index = mkfastq_force_single_index,
                         filter_single_index = mkfastq_filter_single_index,
                         use_bases_mask = mkfastq_use_bases_mask,
                         delete_undetermined = mkfastq_delete_undetermined,
@@ -212,6 +215,7 @@ workflow cellranger_workflow {
                         output_directory = output_directory_stripped,
                         delete_input_bcl_directory = delete_input_bcl_directory,
                         barcode_mismatches = mkfastq_barcode_mismatches,
+                        force_single_index = mkfastq_force_single_index,
                         filter_single_index = mkfastq_filter_single_index,
                         use_bases_mask = mkfastq_use_bases_mask,
                         delete_undetermined = mkfastq_delete_undetermined,
@@ -239,6 +243,7 @@ workflow cellranger_workflow {
                         output_directory = output_directory_stripped,
                         delete_input_bcl_directory = delete_input_bcl_directory,
                         barcode_mismatches = mkfastq_barcode_mismatches,
+                        force_single_index = mkfastq_force_single_index,
                         filter_single_index = mkfastq_filter_single_index,
                         use_bases_mask = mkfastq_use_bases_mask,
                         delete_undetermined = mkfastq_delete_undetermined,


### PR DESCRIPTION
This is to solve the feature request from Broad Institute users working on their GP samples.