### PR TITLE
Add optimized GRCh38 and mm10 genome references

### DIFF
--- a/docs/cellranger/sc_sn_rnaseq.rst
+++ b/docs/cellranger/sc_sn_rnaseq.rst
@@ -19,6 +19,10 @@ Sample sheet
 		  - Mouse mm10 (GENCODE vM23/Ensembl 98)
 		* - **GRCh38_and_mm10-2020-A**
 		  - Human GRCh38 (GENCODE v32/Ensembl 98) and mouse mm10 (GENCODE vM23/Ensembl 98)
+		* - **GRCh38-optimized-v1**
+		  - Human GRCh38 scRNA-seq optimized transcriptome reference v1.0, introduced by `[Pool et al. bioRxiv 2022]`_.
+		* - **mm10-optimized-v1**
+		  - Mouse mm10 scRNA-seq optimized transcriptome reference v1.0, introduced by `[Pool et al. bioRxiv 2022]`_.
 		* - **GRCh38_v3.0.0**
 		  - Human GRCh38, cellranger reference 3.0.0, Ensembl v93 gene annotation
 		* - **hg19_v3.0.0**
@@ -274,5 +278,6 @@ See the table below for important sc/snRNA-seq outputs.
 
 
 .. _Carly Ziegler: http://shaleklab.com/author/carly/
+.. _[Pool et al. bioRxiv 2022]: https://www.biorxiv.org/content/10.1101/2022.04.26.489449v1
 .. _[Kim et al. Cell 2020]: https://www.sciencedirect.com/science/article/pii/S0092867420304062
 .. _10x single cell RNA-seq sample index set names: https://support.10xgenomics.com/single-cell-gene-expression/index/doc/specifications-sample-index-sets-for-single-cell-3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/starsolo.rst
+++ b/docs/starsolo.rst
@@ -455,9 +455,9 @@ Required inputs are highlighted **in bold**.
       - "quay.io/cumulus"
       - "quay.io/cumulus"
     * - star_version
-      - STAR version to use. Currently support: ``2.7.9a``.
-      - "2.7.9a"
-      - "2.7.9a"
+      - STAR version to use. Currently support: ``2.7.9a`` and ``2.7.10a`` (`2.7.10a_alpha_220601 <https://github.com/alexdobin/STAR/releases/tag/2.7.10a_alpha_220601>`_).
+      - "2.7.10a"
+      - "2.7.10a"
     * - num_cpu
       - Number of CPUs to request for count per sample.
       - 32

--- a/docs/starsolo.rst
+++ b/docs/starsolo.rst
@@ -394,6 +394,10 @@ We've built the following scRNA-seq references for users' convenience:
       - Mouse mm10, comparable to cellranger reference 2020-A (GENCODE vM23/Ensembl 98)
     * - **GRCh38-and-mm10-2020-A**
       - Human GRCh38 (GENCODE v32/Ensembl 98) and mouse mm10 (GENCODE vM23/Ensembl 98)
+    * - **GRCh38-optimized-v1**
+      - Human GRCh38 scRNA-seq optimized transcriptome reference v1.0, introduced by `[Pool et al., bioRxiv 2022]`_.
+    * - **mm10-optimized-v1**
+      - Mouse mm10 scRNA-seq optimized transcriptome reference v1.0, introduced by `[Pool et al., bioRxiv 2022]`_.
 
 .. note::
   For **snRNA-seq** data, please choose the corresponding scRNA-seq reference above, and add ``GeneFull`` in the *soloFeatures* input.
@@ -507,4 +511,5 @@ Required inputs are highlighted **in bold**.
 
 .. _Import workflows to Terra: ./cumulus_import.html
 .. _genome reference: ./starsolo.html#prebuilt-genome-references
+.. _[Pool et al., bioRxiv 2022]: https://www.biorxiv.org/content/10.1101/2022.04.26.489449v1
 .. _10x HDF5 format: https://support.10xgenomics.com/single-cell-gene-expression/software/pipelines/latest/advanced/h5_matrices

--- a/docs/starsolo.rst
+++ b/docs/starsolo.rst
@@ -366,9 +366,9 @@ See the table below for *star_solo* workflow outputs.
     * - Name
       - Type
       - Description
-    * - output_folder
-      - String
-      - | Google Bucket URI of output directory. Within it, each folder is for one sample in the input sample sheet.
+    * - count_outputs
+      - Array[String]
+      - | Google Bucket URI of output directories of all samples. Each folder is for one sample in the input sample sheet.
         | For the count matrices generated, taking ``Gene`` solo feature for example, they are in ``<output_folder>/<sample_id>/Solo.out/Gene/raw/`` and ``<output_folder>/<sample_id>/Solo.out/Gene/filtered/`` subfolders.
         | Inside each subfolder, there are 2 formats: ``mtx``, and ``h5`` following `10x HDF5 format`_.
     * - starsoloLogs

--- a/workflows/cellranger/index.tsv
+++ b/workflows/cellranger/index.tsv
@@ -1,6 +1,8 @@
 GRCh38-2020-A	gs://regev-lab/resources/cellranger/refdata-gex-GRCh38-2020-A.tar.gz
 mm10-2020-A	gs://regev-lab/resources/cellranger/refdata-gex-mm10-2020-A.tar.gz
 GRCh38_and_mm10-2020-A	gs://regev-lab/resources/cellranger/refdata-gex-GRCh38-and-mm10-2020-A.tar.gz
+GRCh38-optimized-v1	gs://regev-lab/resources/cellranger/GRCh38-optimized-v1.tar.gz
+mm10-optimized-v1	gs://regev-lab/resources/cellranger/mm10-optimized-v1.tar.gz
 GRCh38_v3.0.0	gs://regev-lab/resources/cellranger/refdata-cellranger-GRCh38-3.0.0.tar.gz
 hg19_v3.0.0	gs://regev-lab/resources/cellranger/refdata-cellranger-hg19-3.0.0.tar.gz
 mm10_v3.0.0	gs://regev-lab/resources/cellranger/refdata-cellranger-mm10-3.0.0.tar.gz

--- a/workflows/starsolo/index.tsv
+++ b/workflows/starsolo/index.tsv
@@ -1,6 +1,8 @@
 GRCh38-2020-A	gs://regev-lab/resources/starsolo/GRCh38-2020-A-starsolo.tar.gz
 mm10-2020-A	gs://regev-lab/resources/starsolo/mm10-2020-A-starsolo.tar.gz
 GRCh38-and-mm10-2020-A	gs://regev-lab/resources/starsolo/GRCh38-and-mm10-2020-A-starsolo.tar.gz
+GRCh38-optimized-v1	gs://regev-lab/resources/starsolo/GRCh38-optimized-v1-starsolo.tar.gz
+mm10-optimized-v1	gs://regev-lab/resources/starsolo/mm10-optimized-v1-starsolo.tar.gz
 tenX_v3	gs://regev-lab/resources/starsolo/3M-february-2018.txt
 tenX_v2	gs://regev-lab/resources/starsolo/737K-august-2016.txt
 tenX_5p	gs://regev-lab/resources/starsolo/737K-august-2016.txt

--- a/workflows/starsolo/starsolo_create_reference.wdl
+++ b/workflows/starsolo/starsolo_create_reference.wdl
@@ -8,7 +8,7 @@ workflow starsolo_create_reference {
         String output_directory
 
         String docker_registry = "quay.io/cumulus"
-        String star_version = "2.7.9a"
+        String star_version = "2.7.10a"
         Int num_cpu = 32
         Int disk_space = 100
         String memory = "80G"

--- a/workflows/starsolo/starsolo_workflow.wdl
+++ b/workflows/starsolo/starsolo_workflow.wdl
@@ -152,7 +152,7 @@ workflow starsolo_workflow {
 
     output {
         Array[File]? starsoloLogs = starsolo_count.starsoloLog
-        String output_folder = output_directory
+        Array[String]? count_outputs = starsolo_count.output_count_directory
     }
 
 }


### PR DESCRIPTION
* Add references for CellRanger and STARsolo workflows.
  * The Cellranger refs are reorganized from https://www.thepoollab.org/resources.
  * The STARsolo refs are built by `starsolo_create_reference` WDL using STAR v2.7.10a.
  * For details on the optimized refs, see https://www.biorxiv.org/content/10.1101/2022.04.26.489449v1.
* Set `2.7.10a` to be the default STAR version of `starsolo_workflow` and `starsolo_create_reference` WDLs.