### PR TITLE
Update Cellranger versions

### DIFF
--- a/docs/cellranger/build_refs.rst
+++ b/docs/cellranger/build_refs.rst
@@ -94,7 +94,7 @@ We provide a wrapper of ``cellranger mkref`` to build sc/snRNA-seq references. P
 		  - Ensembl v94
 		  -
 		* - cellranger_version
-		  - cellranger version, could be: ``6.1.2``, ``6.1.1``
+		  - cellranger version, could be: ``7.0.0``, ``6.1.2``, ``6.1.1``
 		  - "6.1.2"
 		  - "6.1.2"
 		* - docker_registry
@@ -213,9 +213,9 @@ We provide a wrapper of ``cellranger-atac mkref`` to build scATAC-seq references
 		  - "gs://fc-e0000000-0000-0000-0000-000000000000/cellranger_atac_reference"
 		  -
 		* - cellranger_atac_version
-		  - cellranger-atac version, could be: 2.0.0, 1.2.0, 1.1.0
-		  - "2.0.0"
-		  - "2.0.0"
+		  - cellranger-atac version, could be: 2.1.0, 2.0.0, 1.2.0, 1.1.0
+		  - "2.1.0"
+		  - "2.1.0"
 		* - docker_registry
 		  - Docker registry to use for cellranger_workflow. Options:
 

--- a/docs/cellranger/build_refs.rst
+++ b/docs/cellranger/build_refs.rst
@@ -95,8 +95,8 @@ We provide a wrapper of ``cellranger mkref`` to build sc/snRNA-seq references. P
 		  -
 		* - cellranger_version
 		  - cellranger version, could be: ``7.0.0``, ``6.1.2``, ``6.1.1``
-		  - "6.1.2"
-		  - "6.1.2"
+		  - "7.0.0"
+		  - "7.0.0"
 		* - docker_registry
 		  - Docker registry to use for cellranger_workflow. Options:
 
@@ -320,9 +320,9 @@ We provide a wrapper of ``cellranger mkvdjref`` to build single-cell immune prof
 		  - Ensembl v94
 		  -
 		* - cellranger_version
-		  - cellranger version, could be: ``6.1.2``, ``6.1.1``
-		  - "6.1.2"
-		  - "6.1.2"
+		  - cellranger version, could be: 7.0.0, 6.1.2, 6.1.1
+		  - "7.0.0"
+		  - "7.0.0"
 		* - docker_registry
 		  - Docker registry to use for cellranger_workflow. Options:
 

--- a/docs/cellranger/feature_barcoding.rst
+++ b/docs/cellranger/feature_barcoding.rst
@@ -187,7 +187,7 @@ For feature barcoding data, ``cellranger_workflow`` takes Illumina outputs as in
 		  - 0.1
 		  - 0.1
 		* - cellranger_version
-		  - cellranger version, could be 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2, 2.2.0
+		  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2, 2.2.0
 		  - "6.1.2"
 		  - "6.1.2"
 		* - cumulus_feature_barcoding_version

--- a/docs/cellranger/feature_barcoding.rst
+++ b/docs/cellranger/feature_barcoding.rst
@@ -187,7 +187,7 @@ For feature barcoding data, ``cellranger_workflow`` takes Illumina outputs as in
 		  - 0.1
 		  - 0.1
 		* - cellranger_version
-		  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2, 2.2.0
+		  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
 		  - "6.1.2"
 		  - "6.1.2"
 		* - cumulus_feature_barcoding_version

--- a/docs/cellranger/feature_barcoding.rst
+++ b/docs/cellranger/feature_barcoding.rst
@@ -188,8 +188,8 @@ For feature barcoding data, ``cellranger_workflow`` takes Illumina outputs as in
 		  - 0.1
 		* - cellranger_version
 		  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
-		  - "6.1.2"
-		  - "6.1.2"
+		  - "7.0.0"
+		  - "7.0.0"
 		* - cumulus_feature_barcoding_version
 		  - Cumulus_feature_barcoding version for extracting feature barcode matrix. Version available: 0.8.0, 0.7.0, 0.6.0, 0.5.0, 0.4.0, 0.3.0, 0.2.0.
 		  - "0.8.0"

--- a/docs/cellranger/sc_atac.rst
+++ b/docs/cellranger/sc_atac.rst
@@ -131,7 +131,7 @@ Workflow input
 	  - "gs://fc-e0000000-0000-0000-0000-000000000000/common_peaks.bed"
 	  -
 	* - cellranger_atac_version
-	  - cellranger-atac version. Available options: 2.0.0, 1.2.0, 1.1.0
+	  - cellranger-atac version. Available options: 2.1.0, 2.0.0, 1.2.0, 1.1.0
 	  - "2.0.0"
 	  - "2.0.0"
 	* - docker_registry

--- a/docs/cellranger/sc_atac.rst
+++ b/docs/cellranger/sc_atac.rst
@@ -132,8 +132,8 @@ Workflow input
 	  -
 	* - cellranger_atac_version
 	  - cellranger-atac version. Available options: 2.1.0, 2.0.0, 1.2.0, 1.1.0
-	  - "2.0.0"
-	  - "2.0.0"
+	  - "2.1.0"
+	  - "2.1.0"
 	* - docker_registry
 	  - Docker registry to use for cellranger_workflow. Options:
 
@@ -267,10 +267,9 @@ To aggregate multiple scATAC-Seq samples, follow the instructions below:
 	  - "gs://fc-e0000000-0000-0000-0000-000000000000/common_peaks.bed"
 	  -
 	* - cellranger_atac_version
-	  - Cell Ranger ATAC version to use.
-	    Options: ``2.0.0``, ``1.2.0``, ``1.1.0``.
-	  - "2.0.0"
-	  - "2.0.0"
+	  - Cell Ranger ATAC version to use. Options: 2.1.0, 2.0.0, 1.2.0, 1.1.0.
+	  - "2.1.0"
+	  - "2.1.0"
 	* - zones
 	  - Google cloud zones
 	  - “us-central1-a us-west1-a”

--- a/docs/cellranger/sc_multiomics.rst
+++ b/docs/cellranger/sc_multiomics.rst
@@ -116,8 +116,8 @@ For single-cell multiomics data, ``cellranger_workflow`` takes Illumina outputs 
 	  -
 	* - include_introns
 	  - Turn this option on to also count reads mapping to intronic regions. With this option, users do not need to use pre-mRNA references. Note that if this option is set, cellranger_version must be >= 5.0.0. This option is used by *cellranger multi* and *cellranger count*.
-	  - false
-	  - false
+	  - true
+	  - true
 	* - arc_gex_exclude_introns
 	  - | Disable counting of intronic reads. In this mode, only reads that are exonic and compatible with annotated splice junctions in the reference are counted.
 	    | **Note:** using this mode will reduce the UMI counts in the feature-barcode matrix.
@@ -151,7 +151,7 @@ For single-cell multiomics data, ``cellranger_workflow`` takes Illumina outputs 
 	  - "gs://fc-e0000000-0000-0000-0000-000000000000/cmo_set.csv"
 	  -
 	* - cellranger_version
-	  - cellranger version, could be 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2
+	  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2
 	  - "6.1.2"
 	  - "6.1.2"
 	* - cellranger_arc_version

--- a/docs/cellranger/sc_multiomics.rst
+++ b/docs/cellranger/sc_multiomics.rst
@@ -152,8 +152,8 @@ For single-cell multiomics data, ``cellranger_workflow`` takes Illumina outputs 
 	  -
 	* - cellranger_version
 	  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
-	  - "6.1.2"
-	  - "6.1.2"
+	  - "7.0.0"
+	  - "7.0.0"
 	* - cellranger_arc_version
 	  - cellranger-arc version, could be 2.0.1, 2.0.0, 1.0.1, 1.0.0
 	  - "2.0.1"

--- a/docs/cellranger/sc_multiomics.rst
+++ b/docs/cellranger/sc_multiomics.rst
@@ -151,7 +151,7 @@ For single-cell multiomics data, ``cellranger_workflow`` takes Illumina outputs 
 	  - "gs://fc-e0000000-0000-0000-0000-000000000000/cmo_set.csv"
 	  -
 	* - cellranger_version
-	  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2
+	  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
 	  - "6.1.2"
 	  - "6.1.2"
 	* - cellranger_arc_version

--- a/docs/cellranger/sc_sn_rnaseq.rst
+++ b/docs/cellranger/sc_sn_rnaseq.rst
@@ -174,8 +174,8 @@ For sc/snRNA-seq data, ``cellranger_workflow`` takes Illumina outputs as input a
 		  -
 		* - include_introns
 		  - Turn this option on to also count reads mapping to intronic regions. With this option, users do not need to use pre-mRNA references. Note that if this option is set, cellranger_version must be >= 5.0.0.
-		  - false
-		  - false
+		  - true
+		  - true
 		* - no_bam
 		  - Turn this option on to disable BAM file generation. This option is only available if cellranger_version >= 5.0.0.
 		  - false
@@ -185,7 +185,7 @@ For sc/snRNA-seq data, ``cellranger_workflow`` takes Illumina outputs as input a
 		  - false
 		  - false
 		* - cellranger_version
-		  - cellranger version, could be 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2, or 2.2.0
+		  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, or 5.0.0
 		  - "6.1.2"
 		  - "6.1.2"
 		* - config_version

--- a/docs/cellranger/sc_sn_rnaseq.rst
+++ b/docs/cellranger/sc_sn_rnaseq.rst
@@ -185,9 +185,9 @@ For sc/snRNA-seq data, ``cellranger_workflow`` takes Illumina outputs as input a
 		  - false
 		  - false
 		* - cellranger_version
-		  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, or 5.0.0
-		  - "6.1.2"
-		  - "6.1.2"
+		  - cellranger version, could be: 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
+		  - "7.0.0"
+		  - "7.0.0"
 		* - config_version
 		  - config docker version used for processing sample sheets, could be 0.2, 0.1
 		  - "0.2"

--- a/docs/cellranger/sc_vdj.rst
+++ b/docs/cellranger/sc_vdj.rst
@@ -119,7 +119,7 @@ For scIR-seq data, ``cellranger_workflow`` takes Illumina outputs as input and r
 	  - "auto"
 	  - "auto"
 	* - cellranger_version
-	  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2, 2.2.0
+	  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
 	  - "6.1.2"
 	  - "6.1.2"
 	* - docker_registry

--- a/docs/cellranger/sc_vdj.rst
+++ b/docs/cellranger/sc_vdj.rst
@@ -119,7 +119,7 @@ For scIR-seq data, ``cellranger_workflow`` takes Illumina outputs as input and r
 	  - "auto"
 	  - "auto"
 	* - cellranger_version
-	  - cellranger version, could be 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2, 2.2.0
+	  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2, 2.2.0
 	  - "6.1.2"
 	  - "6.1.2"
 	* - docker_registry

--- a/docs/cellranger/sc_vdj.rst
+++ b/docs/cellranger/sc_vdj.rst
@@ -120,8 +120,8 @@ For scIR-seq data, ``cellranger_workflow`` takes Illumina outputs as input and r
 	  - "auto"
 	* - cellranger_version
 	  - cellranger version, could be 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
-	  - "6.1.2"
-	  - "6.1.2"
+	  - "7.0.0"
+	  - "7.0.0"
 	* - docker_registry
 	  - Docker registry to use for cellranger_workflow. Options:
 

--- a/workflows/cellranger/cellranger_atac_aggr.wdl
+++ b/workflows/cellranger/cellranger_atac_aggr.wdl
@@ -23,8 +23,8 @@ workflow cellranger_atac_aggr {
         # A BED file to override peak caller
         File? peaks
 
-        # 2.0.0, 1.2.0, 1.1.0
-        String cellranger_atac_version = "2.0.0"
+        # 2.1.0, 2.0.0, 1.2.0, 1.1.0
+        String cellranger_atac_version = "2.1.0"
         # Which docker registry to use: cumulusprod (default) or quay.io/cumulus
         String docker_registry = "quay.io/cumulus"
 

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -4,8 +4,8 @@ workflow cellranger_atac_create_reference {
     input {
         # Which docker registry to use
         String docker_registry = "quay.io/cumulus"
-        # cellranger-atac version: 2.0.0, 1.2.0, 1.1.0
-        String cellranger_atac_version = "2.0.0"
+        # cellranger-atac version: 2.1.0, 2.0.0, 1.2.0, 1.1.0
+        String cellranger_atac_version = "2.1.0"
 
         # Disk space in GB
         Int disk_space = 100

--- a/workflows/cellranger/cellranger_create_reference.wdl
+++ b/workflows/cellranger/cellranger_create_reference.wdl
@@ -22,8 +22,8 @@ workflow cellranger_create_reference {
 
         # Which docker registry to use
         String docker_registry = "quay.io/cumulus"
-        # 6.1.2, 6.1.1
-        String cellranger_version = "6.1.2"
+        # 7.0.0, 6.1.2, 6.1.1
+        String cellranger_version = "7.0.0"
 
         # Disk space in GB
         Int disk_space = 100

--- a/workflows/cellranger/cellranger_vdj_create_reference.wdl
+++ b/workflows/cellranger/cellranger_vdj_create_reference.wdl
@@ -16,8 +16,8 @@ workflow cellranger_vdj_create_reference {
 
         # Which docker registry to use
         String docker_registry = "quay.io/cumulus"
-        # 6.1.2, 6.1.1
-        String cellranger_version = "6.1.2"
+        # 7.0.0, 6.1.2, 6.1.1
+        String cellranger_version = "7.0.0"
 
         # Disk space in GB
         Int disk_space = 100

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -99,11 +99,11 @@ workflow cellranger_workflow {
         File acronym_file = "gs://regev-lab/resources/cellranger/index.tsv"
 
         # 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
-        String cellranger_version = "6.1.2"
+        String cellranger_version = "7.0.0"
         # 0.8.0, 0.7.0, 0.6.0, 0.5.0, 0.4.0, 0.3.0, 0.2.0
         String cumulus_feature_barcoding_version = "0.8.0"
         # 2.1.0, 2.0.0, 1.2.0, 1.1.0
-        String cellranger_atac_version = "2.0.0"
+        String cellranger_atac_version = "2.1.0"
         # 2.0.1, 2.0.0, 1.0.1, 1.0.0
         String cellranger_arc_version = "2.0.1"
         # 0.2

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -45,7 +45,7 @@ workflow cellranger_workflow {
         # Expected number of recovered cells. Mutually exclusive with force_cells
         Int? expect_cells
         # If count reads mapping to intronic regions
-        Boolean include_introns = false
+        Boolean include_introns = true
         # If generate bam outputs. This is also a spaceranger argument.
         Boolean no_bam = false
         # Perform secondary analysis of the gene-barcode matrix (dimensionality reduction, clustering and visualization). Default: false.
@@ -98,11 +98,11 @@ workflow cellranger_workflow {
         # Index TSV file
         File acronym_file = "gs://regev-lab/resources/cellranger/index.tsv"
 
-        # 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0, 4.0.0, 3.1.0, 3.0.2, 2.2.0
+        # 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
         String cellranger_version = "6.1.2"
         # 0.8.0, 0.7.0, 0.6.0, 0.5.0, 0.4.0, 0.3.0, 0.2.0
         String cumulus_feature_barcoding_version = "0.8.0"
-        # 2.0.0, 1.2.0, 1.1.0
+        # 2.1.0, 2.0.0, 1.2.0, 1.1.0
         String cellranger_atac_version = "2.0.0"
         # 2.0.1, 2.0.0, 1.0.1, 1.0.0
         String cellranger_arc_version = "2.0.1"


### PR DESCRIPTION
* Default cellranger version is `7.0.0`.
* Default cellranger-atac version is `2.1.0`.
* In cellranger_workflow.wdl, default of `include_introns` is `true`.
* Retire cellranger versions before `5.0.0`, as `include_introns` only works for CellRanger v5.0.0+.