### PR TITLE
Add output_directory check before execution

### DIFF
--- a/docker/config/0.3/Dockerfile
+++ b/docker/config/0.3/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:bullseye-slim
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get -qq update && \
+    apt-get -qq -y install --no-install-recommends \
+        python3 \
+        python3-pip && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    python -m pip install --upgrade pip --no-cache-dir && \
+    python -m pip install numpy==1.22.4 --no-cache-dir && \
+    python -m pip install pandas==1.4.2 --no-cache-dir && \
+    python -m pip install XlsxWriter==3.0.3 --no-cache-dir && \
+    apt-get -qq -y remove python3-pip && \
+    apt-get -qq -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
+
+RUN mkdir /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/yiming/docker/config/check_uri.py /software

--- a/docker/config/check_uri.py
+++ b/docker/config/check_uri.py
@@ -1,0 +1,12 @@
+import sys
+
+if __name__ == "__main__":
+    backend = sys.argv[1]
+    uri_name = sys.argv[2]
+
+    if backend == 'gcp':
+        assert uri_name.startswith('gs://'), f"Your output directory '{uri_name}' does not match {backend} backend"
+    elif backend == 'aws':
+        assert uri_name.startswith('s3://'), f"Your output directory '{uri_name}' does not match {backend} backend"
+    else:
+        assert (not uri_name.startswith('s3://')) and (not uri_name.startswith('gs://')), f"Your output directory '{uri_name}' does not match {backend} backend"

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -106,8 +106,8 @@ workflow cellranger_workflow {
         String cellranger_atac_version = "2.1.0"
         # 2.0.1, 2.0.0, 1.0.1, 1.0.0
         String cellranger_arc_version = "2.0.1"
-        # 0.2
-        String config_version = "0.2"
+        # config version
+        String config_version = "0.3"
 
         # Which docker registry to use: quay.io/cumulus (default) or cumulusprod
         String docker_registry = "quay.io/cumulus"
@@ -576,19 +576,14 @@ task generate_bcl_csv {
         set -e
         export TMPDIR=/tmp
 
+        python /software/check_uri.py "~{backend}" "~{output_dir}"
+
         python <<CODE
         import os
         import re
         import sys
         import pandas as pd
         from collections import defaultdict
-
-        if "~{backend}" == 'gcp':
-            assert "~{output_dir}".startswith('gs://'), "Your output directory ~{output_dir} does not match ~{backend} backend"
-        elif "~{backend}" == 'aws':
-            assert "~{output_dir}".startswith('s3://'), "Your output directory ~{output_dir} does not match ~{backend} backend"
-        else:
-            assert (not "~{output_dir}".startswith('s3://')) and (not "~{output_dir}".startswith('gs://')), "Your output directory ~{output_dir} does not match ~{backend} backend"
 
         df = pd.read_csv('~{input_csv_file}', header = 0, dtype = str, index_col = False)
         df.columns = df.columns.str.strip()
@@ -671,19 +666,14 @@ task generate_count_config {
         set -e
         export TMPDIR=/tmp
 
+        python /software/check_uri.py "~{backend}" "~{output_dir}"
+
         python <<CODE
         import os
         import re
         import sys
         import pandas as pd
         from collections import defaultdict
-
-        if "~{backend}" == 'gcp':
-            assert "~{output_dir}".startswith('gs://'), "Your output directory ~{output_dir} does not match ~{backend} backend"
-        elif "~{backend}" == 'aws':
-            assert "~{output_dir}".startswith('s3://'), "Your output directory ~{output_dir} does not match ~{backend} backend"
-        else:
-            assert (not "~{output_dir}".startswith('s3://')) and (not "~{output_dir}".startswith('gs://')), "Your output directory ~{output_dir} does not match ~{backend} backend"
 
         df = pd.read_csv('~{input_csv_file}', header = 0, dtype = str, index_col = False)
         df.columns = df.columns.str.strip()

--- a/workflows/demultiplexing/demultiplexing.wdl
+++ b/workflows/demultiplexing/demultiplexing.wdl
@@ -100,8 +100,8 @@ workflow demultiplexing {
         # Extra disk space (integer) in GB needed for popscle per pair
         Int popscle_extra_disk_space = 100
 
-        # Version of config docker image to use. This docker is used for parsing the input sample sheet for downstream execution. Available options: "0.2", "0.1"
-        String config_version = "0.2"
+        # Version of config docker image to use. This docker is used for parsing the input sample sheet for downstream execution. Available options: 0.3, 0.2, 0.1
+        String config_version = "0.3"
     }
 
     String output_directory_stripped = sub(output_directory, "[/\\s]+$", "")
@@ -109,6 +109,7 @@ workflow demultiplexing {
     call generate_demux_config as Config {
         input:
             input_sample_sheet = input_sample_sheet,
+            output_dir = output_directory_stripped,
             config_version = config_version,
             docker_registry = docker_registry,
             zones = zones,
@@ -225,6 +226,7 @@ workflow demultiplexing {
 task generate_demux_config {
     input {
         File input_sample_sheet
+        String output_dir
         String config_version
         String docker_registry
         String zones
@@ -236,6 +238,8 @@ task generate_demux_config {
     command {
         set -e
         export TMPDIR=/tmp
+
+        python /software/check_uri.py "~{backend}" "~{output_dir}"
 
         python <<CODE
         import re, sys

--- a/workflows/spaceranger/spaceranger_workflow.wdl
+++ b/workflows/spaceranger/spaceranger_workflow.wdl
@@ -34,8 +34,8 @@ workflow spaceranger_workflow {
 
         # Space Ranger version: 1.3.1, 1.3.0
         String spaceranger_version = "1.3.1"
-        # Config version: 0.2
-        String config_version = "0.2"
+        # Config version
+        String config_version = "0.3"
 
         # Which docker registry to use: quay.io/cumulus (default) or cumulusprod
         String docker_registry = "quay.io/cumulus"
@@ -76,6 +76,7 @@ workflow spaceranger_workflow {
         call generate_bcl_csv {
             input:
                 input_csv_file = input_csv_file,
+                output_dir = output_directory_stripped,
                 config_version = config_version,
                 docker_registry = docker_registry_stripped,
                 zones = zones,
@@ -113,6 +114,7 @@ workflow spaceranger_workflow {
         call generate_count_config {
             input:
                 input_csv_file = input_csv_file,
+                output_dir = output_directory_stripped,
                 fastq_dirs = spaceranger_mkfastq.output_fastqs_flowcell_directory,
                 config_version = config_version,
                 docker_registry = docker_registry_stripped,
@@ -179,6 +181,7 @@ workflow spaceranger_workflow {
 task generate_bcl_csv {
     input {
         File input_csv_file
+        String output_dir
         String config_version
         String docker_registry
         String zones
@@ -190,6 +193,8 @@ task generate_bcl_csv {
     command {
         set -e
         export TMPDIR=/tmp
+
+        python /software/check_uri.py "~{backend}" "~{output_dir}"
 
         python <<CODE
         import os
@@ -236,6 +241,7 @@ task generate_bcl_csv {
 task generate_count_config {
     input {
         File input_csv_file
+        String output_dir
         Array[String]? fastq_dirs
         String config_version
         String docker_registry
@@ -249,6 +255,8 @@ task generate_count_config {
     command {
         set -e
         export TMPDIR=/tmp
+
+        python /software/check_uri.py "~{backend}" "~{output_dir}"
 
         python <<CODE
         import os


### PR DESCRIPTION
* Wrap the checking code as a Python script built into `config:0.3` docker image.
* Apply the check to Cellranger, Spaceranger, STARsolo and Demultiplexing workflows.
* STARsolo workflow's config task now uses `config` docker image.