### PR TITLE
Fix monitoring script for AWS

### DIFF
--- a/docker/cellranger-arc/2.0.1/Dockerfile
+++ b/docker/cellranger-arc/2.0.1/Dockerfile
@@ -16,10 +16,10 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.20.zip" -o "a
 RUN pip3 install --upgrade pip && \
     pip3 install pandas==1.2.5 && \
     pip3 install packaging==21.0 && \
-    pip3 install stratocumulus==0.1.5
+    pip3 install stratocumulus==0.1.7
 
 RUN mkdir /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 ADD cellranger-arc-2.0.1.tar.gz /software
 
 #ADD bcl2fastq2-v2-20-0-linux-x86-64.zip /software/

--- a/docker/cellranger-atac/2.1.0/Dockerfile
+++ b/docker/cellranger-atac/2.1.0/Dockerfile
@@ -20,7 +20,7 @@ RUN python -m pip install --upgrade pip && \
     python -m pip install stratocumulus==0.1.7
 
 RUN mkdir /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 ADD cellranger-atac-2.1.0.tar.gz /software
 
 RUN apt-get -qq -y autoremove && \

--- a/docker/cellranger/7.0.0/Dockerfile
+++ b/docker/cellranger/7.0.0/Dockerfile
@@ -22,7 +22,7 @@ RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install stratocumulus==0.1.7 --no-cache-dir
 
 RUN mkdir /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 ADD cellranger-7.0.0.tar.gz /software
 
 RUN apt-get -qq -y autoremove && \

--- a/docker/chromap/0.1.5/Dockerfile
+++ b/docker/chromap/0.1.5/Dockerfile
@@ -17,7 +17,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.27.zip" -o "a
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN python -m pip install --upgrade pip --no-cache-dir && \
-    python -m pip install stratocumulus==0.1.5 --no-cache-dir
+    python -m pip install stratocumulus==0.1.7 --no-cache-dir
 
 RUN mkdir /software && \
     wget https://github.com/haowenz/chromap/archive/refs/tags/v0.1.5.zip && \
@@ -32,7 +32,7 @@ RUN apt-get -qq -y remove curl gnupg unzip wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 RUN chmod a+rx /software/monitor_script.sh
 
 ENV PATH=/software:/software/chromap-0.1.5:$PATH

--- a/docker/cumulus/1.4.3/Dockerfile
+++ b/docker/cumulus/1.4.3/Dockerfile
@@ -62,12 +62,12 @@ RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install harmony-pytorch==0.1.6 --no-cache-dir && \
     python -m pip install cirrocumulus==1.1.17.post1 --no-cache-dir && \
     python -m pip install annoy==1.17.0 --no-cache-dir && \
-    python -m pip install pegasusio==0.4.1 --no-cache-dir && \
+    python -m pip install pegasusio==0.6.1 --no-cache-dir && \
     python -m pip install demuxEM==0.1.6 --no-cache-dir && \
     python -m pip install forceatlas2-python==1.1 --no-cache-dir && \
     python -m pip install nmf-torch==0.1.1 --no-cache-dir && \
     python -m pip install pegasuspy==1.4.3 --no-cache-dir && \
-    python -m pip install stratocumulus==0.1.1 --no-cache-dir
+    python -m pip install stratocumulus==0.1.7 --no-cache-dir
 
 RUN apt-get -qq -y remove curl gnupg unzip && \
     apt-get -qq -y autoremove && \
@@ -75,7 +75,7 @@ RUN apt-get -qq -y remove curl gnupg unzip && \
     rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 
 RUN mkdir /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 RUN chmod a+rx /software/monitor_script.sh
 
 ENV PATH=/software:$PATH

--- a/docker/demultiplexing/demuxem/0.1.7/Dockerfile
+++ b/docker/demultiplexing/demuxem/0.1.7/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get -qq -y remove curl gnupg && \
     rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 
 RUN mkdir /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 RUN chmod a+rx /software/monitor_script.sh
 
 ENV PATH=/software:$PATH

--- a/docker/demultiplexing/popscle/0.1b/Dockerfile
+++ b/docker/demultiplexing/popscle/0.1b/Dockerfile
@@ -46,12 +46,12 @@ RUN pip install --upgrade pip && \
     pip install argparse==1.4.0 && \
     pip install networkx==2.5.1 && \
     pip install pegasusio==0.3.1.post2 && \
-    pip install stratocumulus==0.1.3
+    pip install stratocumulus==0.1.7
 
 RUN mkdir /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/demultiplexing/souporcell/extract_barcodes_from_rna.py /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/demultiplexing/popscle/popscle_generate_zarr.py /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/demultiplexing/souporcell/extract_barcodes_from_rna.py /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/demultiplexing/popscle/popscle_generate_zarr.py /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 RUN chmod a+rx /software/monitor_script.sh
 
 ENV PATH=/software:$PATH

--- a/docker/demultiplexing/popscle/2021.05/Dockerfile
+++ b/docker/demultiplexing/popscle/2021.05/Dockerfile
@@ -64,16 +64,16 @@ RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install argparse==1.4.0 --no-cache-dir && \
     python -m pip install networkx==2.5.1 --no-cache-dir && \
     python -m pip install pegasusio==0.3.1.post2 --no-cache-dir && \
-    python -m pip install stratocumulus==0.1.3 --no-cache-dir
+    python -m pip install stratocumulus==0.1.7 --no-cache-dir
 
 RUN apt-get -qq -y remove curl gnupg wget && \
     apt-get -qq -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/demultiplexing/souporcell/extract_barcodes_from_rna.py /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/demultiplexing/popscle/popscle_generate_zarr.py /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/demultiplexing/souporcell/extract_barcodes_from_rna.py /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/demultiplexing/popscle/popscle_generate_zarr.py /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 RUN chmod a+rx /software/monitor_script.sh
 
 ENV PATH=/software/popscle/bin:/software:$PATH

--- a/docker/demultiplexing/souporcell/2021.03/Dockerfile
+++ b/docker/demultiplexing/souporcell/2021.03/Dockerfile
@@ -59,7 +59,7 @@ RUN conda install -y python=3.6.13 && \
     conda install -y -c conda-forge numpy=1.19.5 pandas=1.1.5 scipy=1.5.3 pyvcf=0.6.8 pystan=2.19.1.1 anndata=0.7.6 zarr=2.8.3 networkx=2.5.1 && \
     conda install -y -c bioconda pysam=0.16.0.1 pyfaidx=0.6.2 pegasusio=0.2.10
 
-RUN pip install stratocumulus==0.1.2
+RUN pip install stratocumulus==0.1.7
 
 RUN cd /opt && \
     wget -O htslib.tar.bz2 https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 && \
@@ -100,10 +100,10 @@ RUN cd /opt && \
     mv vartrix_linux vartrix && \
     chmod 777 vartrix
 
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/demultiplexing/souporcell/extract_barcodes_from_rna.py /opt
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/demultiplexing/souporcell/match_donors.py /opt
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/demultiplexing/souporcell/extract_barcodes_from_rna.py /opt
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/demultiplexing/souporcell/match_donors.py /opt
 
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /opt
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /opt
 RUN chmod a+rx /opt/monitor_script.sh
 
 ENV PATH=/opt/vartrix:/opt:$PATH

--- a/docker/monitor_script.sh
+++ b/docker/monitor_script.sh
@@ -2,9 +2,19 @@
 
 declare -a TEMP=$(mktemp /temp_monitoring.XXXXXXXX)
 
+if [[ -z "${BACKEND}" ]]; then
+        backend=""
+else
+        backend=${BACKEND}
+fi
+
 function get_disk_info() {
         # df command and cromwell root field
-        df | grep cromwell_root
+        if [ "$backend" = "aws" ]; then
+                df | grep '/$'
+        else
+                df | grep cromwell_root
+        fi
 }
 
 function get_disk_usage() {
@@ -97,7 +107,12 @@ function print_summary() {
         echo \#CPU: $(nproc)
         # multiply by 10^-6 to convert KB to GB
         echo Total Memory: $(echo $(get_mem_total) 1000000 | awk '{ print $1/$2 }')G
-        echo Total Disk space: $(df -h | grep cromwell_root | awk '{ print $2}')
+
+        if [ "$backend" = "aws" ]; then
+                echo Total Disk space: $(df -h | grep '/$' | awk '{ print $2 }')
+        else
+                echo Total Disk space: $(df -h | grep cromwell_root | awk '{ print $2}')
+        fi
 }
 
 function main() {

--- a/docker/shareseq/shareseq_mkfastq/0.1.0/Dockerfile
+++ b/docker/shareseq/shareseq_mkfastq/0.1.0/Dockerfile
@@ -18,18 +18,18 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install pandas==1.2.5 --no-cache-dir && \
     python -m pip install packaging==21.0 --no-cache-dir && \
-    python -m pip install stratocumulus==0.1.3 --no-cache-dir
+    python -m pip install stratocumulus==0.1.7 --no-cache-dir
 
 RUN mkdir /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/shareseq/shareseq_mkfastq/scripts/shareseq2bcl /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/shareseq/shareseq_mkfastq/scripts/remove_prefix.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/shareseq/shareseq_mkfastq/scripts/shareseq2bcl /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/shareseq/shareseq_mkfastq/scripts/remove_prefix.sh /software
 
 ADD bcl2fastq2-v2-20-0-linux-x86-64.zip /software/
 RUN unzip -d /software/ /software/bcl2fastq2-v2-20-0-linux-x86-64.zip && alien -i /software/bcl2fastq2-v2.20.0.422-Linux-x86_64.rpm && rm -f /software/bcl2fastq2-v2*
 
 RUN mkdir /indices
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/shareseq/shareseq_mkfastq/indices/shareseq_sample_index.csv /indices/
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/shareseq/shareseq_mkfastq/indices/shareseq_sample_index.csv /indices/
 
 RUN apt-get -qq -y remove alien curl gnupg python3-pip unzip && \
     apt-get -qq -y autoremove && \

--- a/docker/shareseq/shareseq_reorg/0.1.0/Dockerfile
+++ b/docker/shareseq/shareseq_reorg/0.1.0/Dockerfile
@@ -18,19 +18,19 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install pandas==1.2.5 --no-cache-dir && \
     python -m pip install packaging==21.0 --no-cache-dir && \
-    python -m pip install stratocumulus==0.1.3 --no-cache-dir
+    python -m pip install stratocumulus==0.1.7 --no-cache-dir
 
 RUN mkdir /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/shareseq/shareseq_reorg/scripts/gzip_utils.hpp /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/shareseq/shareseq_reorg/scripts/barcode_utils.hpp /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/shareseq/shareseq_reorg/scripts/shareseq_reorg_barcodes.cpp /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/shareseq/shareseq_reorg/scripts/Makefile /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/shareseq/shareseq_reorg/scripts/gzip_utils.hpp /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/shareseq/shareseq_reorg/scripts/barcode_utils.hpp /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/shareseq/shareseq_reorg/scripts/shareseq_reorg_barcodes.cpp /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/shareseq/shareseq_reorg/scripts/Makefile /software
 RUN cd /software && make clean && make all && cd ..
 
 RUN mkdir /indices
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/shareseq/shareseq_reorg/indices/shareseq_barcode_index.csv /indices/
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/shareseq/shareseq_reorg/indices/shareseq_flanking_sequence.csv /indices/
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/shareseq/shareseq_reorg/indices/shareseq_barcode_index.csv /indices/
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/shareseq/shareseq_reorg/indices/shareseq_flanking_sequence.csv /indices/
 
 RUN apt-get -qq -y remove alien curl gnupg python3-pip unzip && \
     apt-get -qq -y autoremove && \

--- a/docker/smartseq2/1.3.0/Dockerfile
+++ b/docker/smartseq2/1.3.0/Dockerfile
@@ -5,8 +5,8 @@ ADD https://github.com/BenLangmead/bowtie2/releases/download/v2.4.2/bowtie2-2.4.
 ADD https://github.com/alexdobin/STAR/archive/2.7.7a.zip /software/
 ADD https://github.com/DaehwanKimLab/hisat2/archive/v2.2.1.zip /software/
 ADD https://github.com/deweylab/RSEM/archive/v1.3.3.zip /software/
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software/
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/smartseq2/generate_matrix_ss2.py /software/
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software/
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/smartseq2/generate_matrix_ss2.py /software/
 
 RUN apt-get -qq update && apt-get -qq -y install --no-install-recommends ca-certificates curl apt-transport-https gnupg lsb-release unzip build-essential zlib1g-dev libncurses5-dev python3 python3-pip \
     && ln -s /usr/bin/python3 /usr/bin/python \
@@ -28,7 +28,7 @@ RUN apt-get -qq update && apt-get -qq -y install --no-install-recommends ca-cert
     && apt-get -qq -y autoremove \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* /var/log/dpkg.log \
-    && chmod a+rx /software/monitor_script.sh \ 
+    && chmod a+rx /software/monitor_script.sh \
     && chmod a+rx /software/generate_matrix_ss2.py
 
 ENV PATH=/software:/software/bowtie2-2.4.2-linux-x86_64:/software/STAR-2.7.7a/bin/Linux_x86_64_static:/software/hisat2-2.2.1:/software/RSEM-1.3.3:$PATH

--- a/docker/spaceranger/1.3.1/Dockerfile
+++ b/docker/spaceranger/1.3.1/Dockerfile
@@ -21,7 +21,7 @@ RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install stratocumulus==0.1.7 --no-cache-dir
 
 RUN mkdir /software
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 ADD spaceranger-1.3.1.tar.gz /software
 
 RUN apt-get -qq -y autoremove && \

--- a/docker/trust4/master/Dockerfile
+++ b/docker/trust4/master/Dockerfile
@@ -17,7 +17,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.4.20.zip" -o "a
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 RUN python -m pip install --upgrade pip --no-cache-dir && \
-    python -m pip install stratocumulus==0.1.5 --no-cache-dir
+    python -m pip install stratocumulus==0.1.7 --no-cache-dir
 
 RUN mkdir /software && \
     git clone https://github.com/liulab-dfci/TRUST4.git && \
@@ -30,8 +30,8 @@ RUN apt-get -qq -y remove curl unzip python3-pip gnupg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/log/dpkg.log && \
     rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
- 
-ADD https://raw.githubusercontent.com/klarman-cell-observatory/cumulus/master/docker/monitor_script.sh /software
+
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 RUN chmod a+rx /software/monitor_script.sh /software/TRUST4/BuildDatabaseFa.pl /software/TRUST4/BuildImgtAnnot.pl
 
 RUN ln -s /software/TRUST4/BuildDatabaseFa.pl .

--- a/workflows/cellbender/cellbender.wdl
+++ b/workflows/cellbender/cellbender.wdl
@@ -140,6 +140,7 @@ task run_cellbender_remove_background_gpu {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         cellbender remove-background \

--- a/workflows/cellranger/cellranger_arc_count.wdl
+++ b/workflows/cellranger/cellranger_arc_count.wdl
@@ -125,6 +125,7 @@ task run_cellranger_arc_count {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         mkdir -p genome_dir
         tar xf ~{genome_file} -C genome_dir --strip-components 1

--- a/workflows/cellranger/cellranger_arc_mkfastq.wdl
+++ b/workflows/cellranger/cellranger_arc_mkfastq.wdl
@@ -103,6 +103,7 @@ task run_cellranger_arc_mkfastq {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         strato cp --backend ~{backend} -r -m ~{input_bcl_directory} .
 

--- a/workflows/cellranger/cellranger_atac_aggr.wdl
+++ b/workflows/cellranger/cellranger_atac_aggr.wdl
@@ -103,6 +103,7 @@ task run_cellranger_atac_aggr {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         mkdir -p genome_dir
         tar xf ~{genome_file} -C genome_dir --strip-components 1

--- a/workflows/cellranger/cellranger_atac_count.wdl
+++ b/workflows/cellranger/cellranger_atac_count.wdl
@@ -104,6 +104,7 @@ task run_cellranger_atac_count {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         mkdir -p genome_dir
         tar xf ~{genome_file} -C genome_dir --strip-components 1

--- a/workflows/cellranger/cellranger_atac_create_reference.wdl
+++ b/workflows/cellranger/cellranger_atac_create_reference.wdl
@@ -91,6 +91,7 @@ task run_cellranger_atac_create_reference {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         python <<CODE

--- a/workflows/cellranger/cellranger_atac_mkfastq.wdl
+++ b/workflows/cellranger/cellranger_atac_mkfastq.wdl
@@ -103,6 +103,7 @@ task run_cellranger_atac_mkfastq {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         strato cp --backend '~{backend}' -m -r ~{input_bcl_directory} .
 

--- a/workflows/cellranger/cellranger_count.wdl
+++ b/workflows/cellranger/cellranger_count.wdl
@@ -132,6 +132,7 @@ task run_cellranger_count {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         mkdir -p genome_dir
         tar xf ~{genome_file} -C genome_dir --strip-components 1

--- a/workflows/cellranger/cellranger_create_reference.wdl
+++ b/workflows/cellranger/cellranger_create_reference.wdl
@@ -189,6 +189,7 @@ task run_filter_gtf {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         python <<CODE
@@ -273,6 +274,7 @@ task run_cellranger_mkref {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         python <<CODE

--- a/workflows/cellranger/cellranger_mkfastq.wdl
+++ b/workflows/cellranger/cellranger_mkfastq.wdl
@@ -103,6 +103,7 @@ task run_cellranger_mkfastq {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         strato sync --backend "~{backend}" -m ~{input_bcl_directory} ~{run_id}
 

--- a/workflows/cellranger/cellranger_multi.wdl
+++ b/workflows/cellranger/cellranger_multi.wdl
@@ -126,6 +126,7 @@ task run_cellranger_multi {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         mkdir -p genome_dir
         tar xf ~{genome_file} -C genome_dir --strip-components 1

--- a/workflows/cellranger/cellranger_vdj.wdl
+++ b/workflows/cellranger/cellranger_vdj.wdl
@@ -105,6 +105,7 @@ task run_cellranger_vdj {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         mkdir -p ref_dir
         tar xf ~{genome_file} -C ref_dir --strip-components 1

--- a/workflows/cellranger/cellranger_vdj_create_reference.wdl
+++ b/workflows/cellranger/cellranger_vdj_create_reference.wdl
@@ -79,6 +79,7 @@ task run_cellranger_vdj_create_reference {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         python <<CODE

--- a/workflows/chromap/chromap_create_reference.wdl
+++ b/workflows/chromap/chromap_create_reference.wdl
@@ -29,7 +29,7 @@ workflow chromap_create_reference {
         Int? kmer
         # Minimum window size
         Int? mini_win_size
-        
+
         # Output directory, URL
         String output_directory
     }
@@ -50,7 +50,7 @@ workflow chromap_create_reference {
             genome = genome,
             kmer = kmer,
             mini_win_size = mini_win_size,
-            input_fasta = input_fasta,           
+            input_fasta = input_fasta,
             output_dir = output_directory_stripped
     }
 
@@ -80,12 +80,13 @@ task run_chromap_create_reference {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
-        
+
         mkdir -p ~{genome}
 
         chromap -i ~{"-k" + kmer} ~{"-w" + mini_win_size} -r ~{input_fasta} -o ~{genome}/ref.index
-        
+
         mv ~{input_fasta} ~{genome}/ref.fa
         tar -czf ~{genome}.tar.gz ~{genome}
         strato cp --backend ~{backend} -m ~{genome}.tar.gz "~{output_dir}"/
@@ -106,6 +107,3 @@ task run_chromap_create_reference {
         maxRetries: if backend == "aws" then awsMaxRetries else 0
     }
 }
-
-
-

--- a/workflows/cumulus/cumulus_adt.wdl
+++ b/workflows/cumulus/cumulus_adt.wdl
@@ -118,6 +118,7 @@ task run_generate_count_matrix_ADTs {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         python <<CODE

--- a/workflows/cumulus/cumulus_tasks.wdl
+++ b/workflows/cumulus/cumulus_tasks.wdl
@@ -28,6 +28,8 @@ task run_cumulus_aggregate_matrices {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
+        monitor_script.sh > monitoring.log &
 
         python <<CODE
         from subprocess import check_call
@@ -63,7 +65,8 @@ task run_cumulus_aggregate_matrices {
     }
 
     output {
-        File output_zarr = '~{output_name}.aggr.zarr.zip'
+        File output_zarr = "~{output_name}.aggr.zarr.zip"
+        File monitoringLog = "monitoring.log"
     }
 
     runtime {
@@ -176,6 +179,7 @@ task run_cumulus_cluster {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         if [ ~{is_url} == true ]; then
@@ -413,6 +417,7 @@ task run_cumulus_cirro_output {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         cirro prepare_data --out "~{output_name}".cirro ~{input_h5ad}
@@ -483,6 +488,7 @@ task run_cumulus_de_analysis {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         if [ ~{is_url} == true ]; then

--- a/workflows/demultiplexing/demuxEM.wdl
+++ b/workflows/demultiplexing/demuxEM.wdl
@@ -111,6 +111,7 @@ task run_demuxEM {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         python <<CODE

--- a/workflows/demultiplexing/popscle.wdl
+++ b/workflows/demultiplexing/popscle.wdl
@@ -130,6 +130,8 @@ task popscle_task {
 
     command {
         set -e
+        export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         mkdir result

--- a/workflows/demultiplexing/souporcell.wdl
+++ b/workflows/demultiplexing/souporcell.wdl
@@ -134,6 +134,7 @@ task run_souporcell {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         mkdir genome_ref
@@ -226,6 +227,7 @@ task match_donors {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         python <<CODE

--- a/workflows/shareseq/shareseq_mkfastq.wdl
+++ b/workflows/shareseq/shareseq_mkfastq.wdl
@@ -91,6 +91,7 @@ task run_shareseq_mkfastq {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         strato sync --backend ~{backend} -m ~{input_bcl_directory} ~{run_id}

--- a/workflows/shareseq/shareseq_reorg.wdl
+++ b/workflows/shareseq/shareseq_reorg.wdl
@@ -87,6 +87,7 @@ task run_shareseq_reorg {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         mkdir -p _out_reorg

--- a/workflows/smartseq2/smartseq2.wdl
+++ b/workflows/smartseq2/smartseq2.wdl
@@ -161,6 +161,8 @@ task run_rsem {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
+        monitor_script.sh > monitoring.log &
 
         mkdir -p rsem_ref
         tar xf ~{reference} -C rsem_ref --strip-components 1
@@ -185,6 +187,7 @@ task run_rsem {
         File rsem_cnt = "~{sample_name}.stat/~{sample_name}.cnt"
         File rsem_model = "~{sample_name}.stat/~{sample_name}.model"
         File rsem_theta = "~{sample_name}.stat/~{sample_name}.theta"
+        File monitoringLog = "monitoring.log"
     }
 
     runtime {
@@ -217,6 +220,8 @@ task generate_count_matrix {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
+        monitor_script.sh > monitoring.log &
 
         generate_matrix_ss2.py ~{sep=',' gene_results} ~{sep=',' count_results} count_matrix
         strato sync --backend ~{backend} -m count_matrix "~{output_directory}"/count_matrix
@@ -224,6 +229,7 @@ task generate_count_matrix {
 
     output {
         String output_count_matrix = "~{output_directory}/count_matrix"
+        File monitoringLog = "monitoring.log"
     }
 
     runtime {

--- a/workflows/smartseq2/smartseq2_create_reference.wdl
+++ b/workflows/smartseq2/smartseq2_create_reference.wdl
@@ -75,6 +75,7 @@ task rsem_prepare_reference {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         mkdir ~{reference_name}_~{aligner}

--- a/workflows/spaceranger/spaceranger_count.wdl
+++ b/workflows/spaceranger/spaceranger_count.wdl
@@ -152,6 +152,7 @@ task run_spaceranger_count {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         mkdir -p genome_dir
         tar xf ~{genome_file} -C genome_dir --strip-components 1

--- a/workflows/spaceranger/spaceranger_mkfastq.wdl
+++ b/workflows/spaceranger/spaceranger_mkfastq.wdl
@@ -87,6 +87,7 @@ task run_spaceranger_mkfastq {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
         strato sync --backend ~{backend} -m ~{input_bcl_directory} ~{run_id}
 

--- a/workflows/starsolo/starsolo_count.wdl
+++ b/workflows/starsolo/starsolo_count.wdl
@@ -155,6 +155,7 @@ task run_starsolo {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         mkdir genome_ref

--- a/workflows/starsolo/starsolo_create_reference.wdl
+++ b/workflows/starsolo/starsolo_create_reference.wdl
@@ -63,6 +63,7 @@ task run_starsolo_create_reference {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
 
         python <<CODE

--- a/workflows/trust4/trust4_create_reference.wdl
+++ b/workflows/trust4/trust4_create_reference.wdl
@@ -53,7 +53,7 @@ workflow trust4_create_reference {
             annotation_gtf = annotation_gtf,
             gene_name_list = gene_name_list,
             species = species,
-            ref_name = ref_name,           
+            ref_name = ref_name,
             output_dir = output_directory_stripped
     }
 
@@ -84,8 +84,9 @@ task run_trust4_create_reference {
     command {
         set -e
         export TMPDIR=/tmp
+        export BACKEND=~{backend}
         monitor_script.sh > monitoring.log &
-        
+
         mkdir -p ~{ref_name}
 
         python <<CODE
@@ -103,9 +104,9 @@ task run_trust4_create_reference {
         if ref_fa.endswith('.gz'):
             ref_fa = uncompress_file(ref_fa)
         if annotation_gtf.endswith('.gz'):
-            annotation_gtf = uncompress_file(annotation_gtf)     
+            annotation_gtf = uncompress_file(annotation_gtf)
 
-        with open('~{ref_name}/bcrtcr.fa', "w") as outfile1: 
+        with open('~{ref_name}/bcrtcr.fa', "w") as outfile1:
             call_args = ['perl', '/BuildDatabaseFa.pl', ref_fa, annotation_gtf, '~{gene_name_list}']
             print(' '.join(call_args))
             run(call_args, stdout = outfile1, check = True)
@@ -118,9 +119,9 @@ task run_trust4_create_reference {
         CODE
 
         tar -czf ~{ref_name}.tar.gz ~{ref_name}
-        
+
         strato cp --backend ~{backend} -m ~{ref_name}.tar.gz ~{output_dir}/
-        
+
 
     }
 
@@ -139,6 +140,3 @@ task run_trust4_create_reference {
         maxRetries: if backend == "aws" then awsMaxRetries else 0
     }
 }
-
-
-


### PR DESCRIPTION
In `docker/monitor.sh`:
* It checks `/cromwell_root` for GCP and local backends.
* It checks `/` for AWS backend.

In WDL tasks using `monitor.sh`:
* It exports an environment variable `BACKEND` with the backend keyword being the value.
* Then `monitor.sh` retrieves this environment variable to determine which mount point to look at for monitoring the disk space.

The check for AWS is different, because AWS genomics CLI uses AWS Batch to handle the on-demand job scheduling. Then one VM instance usually holds multiple jobs, each of which has a dedicated docker container. In this way, `/cromwell_root` is not used, but instead the root `/` within each docker is the mount point for disk space.