### PR TITLE
Fix cyclic dependency on cluster.output_h5ad used for both input and output variable name

### DIFF
--- a/workflows/cumulus/cumulus.wdl
+++ b/workflows/cumulus/cumulus.wdl
@@ -386,8 +386,8 @@ workflow cumulus {
             backend = backend
     }
 
-    if (length(cluster.output_h5ad) > 0) {
-        scatter (focus_h5ad in cluster.output_h5ad) {
+    if (length(cluster.output_h5ad_file) > 0) {
+        scatter (focus_h5ad in cluster.output_h5ad_file) {
             String focus_prefix = basename(focus_h5ad, ".h5ad")
 
             if (perform_de_analysis) {
@@ -493,7 +493,7 @@ workflow cumulus {
         File? output_aggr_zarr = aggregate_matrices.output_zarr
         File output_zarr = cluster.output_zarr
         File output_cluster_log = cluster.output_log
-        Array[File] output_h5ad = cluster.output_h5ad
+        Array[File] output_h5ad_file = cluster.output_h5ad_file
         Array[File] output_filt_xlsx = cluster.output_filt_xlsx
         Array[File] output_filt_plot = cluster.output_filt_plot
         Array[File] output_hvf_plot = cluster.output_hvf_plot

--- a/workflows/cumulus/cumulus_tasks.wdl
+++ b/workflows/cumulus/cumulus_tasks.wdl
@@ -376,7 +376,7 @@ task run_cumulus_cluster {
 
     output {
         File output_zarr = "~{output_name}.zarr.zip"
-        Array[File] output_h5ad = glob("~{output_name}.*.h5ad")
+        Array[File] output_h5ad_file = glob("~{output_name}.*.h5ad")
         Array[File] output_filt_xlsx = glob("~{output_name}.*.filt.xlsx")
         Array[File] output_filt_plot = glob("~{output_name}.*.filt.*.pdf")
         Array[File] output_hvf_plot = glob("~{output_name}.*.hvf.pdf")


### PR DESCRIPTION
This is to work with Cromwell v81+ type check.