### PR TITLE
Bug fix for localizing GCP folders in ATAC and ARC count WDLs

### DIFF
--- a/workflows/cellranger/cellranger_arc_count.wdl
+++ b/workflows/cellranger/cellranger_arc_count.wdl
@@ -146,7 +146,7 @@ task run_cellranger_arc_count {
                     call_args = ['strato', 'exists', '--backend', '~{backend}', directory + '/' + samples[i] + '/']
                     print(' '.join(call_args))
                     check_call(call_args, stdout=DEVNULL, stderr=STDOUT)
-                    call_args = ['strato', 'cp', '--backend', '~{backend}', '-m', '-r', directory + '/' + samples[i], target]
+                    call_args = ['strato', 'sync', '--backend', '~{backend}', '-m', directory + '/' + samples[i], target]
                     print(' '.join(call_args))
                     check_call(call_args)
                 except CalledProcessError:

--- a/workflows/cellranger/cellranger_atac_count.wdl
+++ b/workflows/cellranger/cellranger_atac_count.wdl
@@ -130,7 +130,7 @@ task run_cellranger_atac_count {
                 call_args = ['strato', 'exists', '--backend', '~{backend}', directory + '/~{sample_id}/']
                 print(' '.join(call_args))
                 check_call(call_args, stdout=DEVNULL, stderr=STDOUT)
-                call_args = ['strato', 'cp', '--backend','~{backend}','-r', '-m', directory + '/~{sample_id}', target]
+                call_args = ['strato', 'sync', '--backend', '-m', directory + '/~{sample_id}', target]
                 print(' '.join(call_args))
                 check_call(call_args)
             except CalledProcessError:


### PR DESCRIPTION
In `cellranger_atac_count.wdl` and `cellranger_arc_count.wdl`, when localizing fastq folders, they use `strato cp -r` command.

However, this would fail for GCP backend, because GCP requires creating the target local folder beforehand.

Therefore, switch to use `strato sync` command instead as it has no such extra requirement for both AWS and GCP.