### PR TITLE
Enable STARsolo to handle out-of-memory in BAM sorting

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -46,7 +46,6 @@ workflows:
         - /.*/
       branches:
         - master
-        - starsolo
   - name: GeoMx_fastq_to_dcc
     subclass: WDL
     publish: true

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -46,6 +46,7 @@ workflows:
         - /.*/
       branches:
         - master
+        - starsolo
   - name: GeoMx_fastq_to_dcc
     subclass: WDL
     publish: true

--- a/docs/starsolo.rst
+++ b/docs/starsolo.rst
@@ -62,7 +62,7 @@ A brief description of the sample sheet format is listed below **(required colum
         - ``SlideSeq``
         - ``ShareSeq``
         - ``None``
-        
+
         If not specified, use the default ``tenX_v3``.
 
 **3.2 Assay-specific preset STARsolo options**
@@ -310,6 +310,14 @@ Below are inputs for *count* workflow. Notice that required inputs are in bold.
       - "BAM SortedByCoordinate"
       - | "BAM SortedByCoordinate" for *tenX_v3*, *tenX_v2*, *SeqWell* and *DropSeq* assay types,
         | "BAM Unsorted" otherwise.
+    * - limitBAMsortRAM
+      - [STAR option] Maximum available RAM (bytes) for sorting BAM. If ``0``, it will be set to the genome index size.
+      - 0
+      - 0
+    * - outBAMsortingBinsN
+      - [STAR option] Number of genome bins fo coordinate-sorting.
+      - 50
+      - 50
     * - star_version
       - STAR version to use. Currently support: ``2.7.9a``, ``2.7.10a`` (`2.7.10a_alpha_220601 <https://github.com/alexdobin/STAR/releases/tag/2.7.10a_alpha_220601>`_).
       - "2.7.10a"

--- a/workflows/starsolo/starsolo_count.wdl
+++ b/workflows/starsolo/starsolo_count.wdl
@@ -36,7 +36,7 @@ workflow starsolo_count {
         String? soloUMIfiltering
         String? soloCellFilter
         String? soloOutFormatFeaturesGeneField3
-        Int? limitBAMsortRAM
+        Float? limitBAMsortRAM
         Int? outBAMsortingBinsN
         String docker_registry
         String star_version
@@ -142,7 +142,7 @@ task run_starsolo {
         String? soloUMIfiltering
         String? soloCellFilter
         String? soloOutFormatFeaturesGeneField3
-        Int? limitBAMsortRAM
+        Float? limitBAMsortRAM
         Int? outBAMsortingBinsN
         String docker_registry
         String version

--- a/workflows/starsolo/starsolo_count.wdl
+++ b/workflows/starsolo/starsolo_count.wdl
@@ -36,6 +36,8 @@ workflow starsolo_count {
         String? soloUMIfiltering
         String? soloCellFilter
         String? soloOutFormatFeaturesGeneField3
+        Int? limitBAMsortRAM
+        Int? outBAMsortingBinsN
         String docker_registry
         String star_version
         String zones
@@ -86,6 +88,8 @@ workflow starsolo_count {
             soloUMIfiltering = soloUMIfiltering,
             soloCellFilter = soloCellFilter,
             soloOutFormatFeaturesGeneField3 = soloOutFormatFeaturesGeneField3,
+            limitBAMsortRAM = limitBAMsortRAM,
+            outBAMsortingBinsN = outBAMsortingBinsN,
             docker_registry = docker_registry,
             version = star_version,
             zones = zones,
@@ -138,6 +142,8 @@ task run_starsolo {
         String? soloUMIfiltering
         String? soloCellFilter
         String? soloOutFormatFeaturesGeneField3
+        Int? limitBAMsortRAM
+        Int? outBAMsortingBinsN
         String docker_registry
         String version
         String zones
@@ -341,6 +347,11 @@ task run_starsolo {
             args_dict['--soloCellFilter'] = remove_extra_space('~{soloCellFilter}').split(' ')
         if '~{soloOutFormatFeaturesGeneField3}' != '':
             args_dict['--soloOutFormatFeaturesGeneField3'] = remove_extra_space('~{soloOutFormatFeaturesGeneField3}').split(' ')
+
+        if '~{limitBAMsortRAM}' != '':
+            args_dict['--limitBAMsortRAM'] = '~{limitBAMsortRAM}'
+        if '~{outBAMsortingBinsN}' != '':
+            args_dict['--outBAMsortingBinsN'] = '~{outBAMsortingBinsN}'
 
         call_args += generate_args_list(args_dict)
 

--- a/workflows/starsolo/starsolo_workflow.wdl
+++ b/workflows/starsolo/starsolo_workflow.wdl
@@ -71,7 +71,7 @@ workflow starsolo_workflow {
         # Reference Index TSV
         File acronym_file = "gs://regev-lab/resources/starsolo/index.tsv"
         # Maximum available RAM (bytes) for sorting BAM. If =0, it will be set to the genome index size. 0 value can only be used with --genomeLoad NoSharedMemory option.
-        Int? limitBAMsortRAM
+        Float? limitBAMsortRAM
         # Number of genome bins fo coordinate-sorting. Default: 50
         Int? outBAMsortingBinsN
         # Disk space in GB needed per sample

--- a/workflows/starsolo/starsolo_workflow.wdl
+++ b/workflows/starsolo/starsolo_workflow.wdl
@@ -70,6 +70,10 @@ workflow starsolo_workflow {
         String docker_registry = "quay.io/cumulus"
         # Reference Index TSV
         File acronym_file = "gs://regev-lab/resources/starsolo/index.tsv"
+        # Maximum available RAM (bytes) for sorting BAM. If =0, it will be set to the genome index size. 0 value can only be used with --genomeLoad NoSharedMemory option.
+        Int? limitBAMsortRAM
+        # Number of genome bins fo coordinate-sorting. Default: 50
+        Int? outBAMsortingBinsN
         # Disk space in GB needed per sample
         Int disk_space = 500
         # Google cloud zones to consider for execution
@@ -136,6 +140,8 @@ workflow starsolo_workflow {
                     soloUMIfiltering = soloUMIfiltering,
                     soloCellFilter = soloCellFilter,
                     soloOutFormatFeaturesGeneField3 = soloOutFormatFeaturesGeneField3,
+                    limitBAMsortRAM = limitBAMsortRAM,
+                    outBAMsortingBinsN = outBAMsortingBinsN,
                     output_directory = output_directory_stripped,
                     docker_registry = docker_registry,
                     star_version = star_version,


### PR DESCRIPTION
This is to fix the issue #371 .

Add two inputs `limitBAMsortRAM` and `outBAMsortingBinsN` to expose the corresponding STAR options.