### PR TITLE
Cellranger FRP accepts custom probe set references

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -16,6 +16,7 @@ workflows:
         - /.*/
       branches:
         - master
+        - custom-probeset
   - name: Spaceranger
     subclass: WDL
     publish: true

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -16,7 +16,6 @@ workflows:
         - /.*/
       branches:
         - master
-        - custom-probeset
   - name: Spaceranger
     subclass: WDL
     publish: true

--- a/docs/cellranger/fixed_rna_profiling.rst
+++ b/docs/cellranger/fixed_rna_profiling.rst
@@ -40,6 +40,7 @@ Sample Sheet
           - FRP probe set v1.0 for mouse. Work with Cell Ranger v7.0+.
 
     If *ProbeSet* column is not set, use **FRP_human_probe_v1.0.1** by default.
+    Custom probe set references are also accepted. Simply put the GS or S3 URI of the custom probe set CSV file for this column.
 
 #. *FeatureBarcodeFile* column.
 

--- a/workflows/cellranger/cellranger_multi.wdl
+++ b/workflows/cellranger/cellranger_multi.wdl
@@ -64,7 +64,8 @@ workflow cellranger_multi {
     File genome_file = (if is_genome_uri then genome else acronym2uri[genome])
 
     # If probe set is specified
-    File probe_set_file = (if probe_set != "null" then acronym2uri[probe_set] else acronym2uri["null_file"])
+    Boolean is_probeset_uri = sub(probe_set, "^.+\\.csv$", "URL") == "URL"
+    File probe_set_file = (if probe_set != "null" then (if is_probeset_uri then probe_set else acronym2uri[probe_set]) else acronym2uri["null_file"])
 
     call run_cellranger_multi {
         input:


### PR DESCRIPTION
Besides keywords of preset probe set references, the workflow also accepts GS/S3 URIs of custom probe set CSV files.