### PR TITLE
Fix spaceranger bug on --colorizedimage

### DIFF
--- a/workflows/spaceranger/spaceranger_count.wdl
+++ b/workflows/spaceranger/spaceranger_count.wdl
@@ -266,7 +266,7 @@ task run_spaceranger_count {
             call_args.extend(['--darkimage=' + x for x in darkimages])
             if has_cyta and "~{dapi_index}" != '':
                 call_args.append('--dapi-index=~{dapi_index}')
-        else:
+        elif has_cimage:
             call_args.append('--colorizedimage=~{colorizedimage}')
 
         if '~{area}' == '' and '~{slide}' == '':


### PR DESCRIPTION
Fix the issue when `colorizedimage` is null while only `cytaimage` is provided.