### PR TITLE
Disk Space for Fixed RNA Profiling

### DIFF
--- a/docs/cellranger/fixed_rna_profiling.rst
+++ b/docs/cellranger/fixed_rna_profiling.rst
@@ -177,10 +177,10 @@ For FRP data, ``cellranger_workflow`` takes Illumina outputs as input and runs `
       - Optional disk space in GB for mkfastq
       - 1500
       - 1500
-    * - count_disk_space
+    * - multi_disk_space
       - Disk space in GB needed for cellranger multi
-      - 500
-      - 500
+      - 2000
+      - 2000
     * - backend
       - Cloud backend for file transfer and computation. Available options:
 

--- a/docs/cellranger/fixed_rna_profiling.rst
+++ b/docs/cellranger/fixed_rna_profiling.rst
@@ -179,8 +179,8 @@ For FRP data, ``cellranger_workflow`` takes Illumina outputs as input and runs `
       - 1500
     * - multi_disk_space
       - Disk space in GB needed for cellranger multi
-      - 2000
-      - 2000
+      - 1500
+      - 1500
     * - backend
       - Cloud backend for file transfer and computation. Available options:
 

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -748,7 +748,7 @@ task generate_count_config {
                 probeset = 'null'
                 if datatype == 'frp':
                     if 'ProbeSet' not in df_local.columns:
-                        probeset = 'FRP_human_probe_v1'
+                        probeset = 'FRP_human_probe_v1.0.1'
                     else:
                         if df_local['ProbeSet'].unique().size > 1:
                             print("Detected multiple probe sets for sample " + sample_id + "!", file = sys.stderr)

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -142,7 +142,7 @@ workflow cellranger_workflow {
         # Optional disk space needed for cell ranger count.
         Int count_disk_space = 500
         # Optional disk space needed for cell ranger multi.
-        Int multi_disk_space = 2000
+        Int multi_disk_space = 1500
         # Optional disk space needed for cell ranger vdj.
         Int vdj_disk_space = 500
         # Optional disk space needed for cumulus_adt

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -141,6 +141,8 @@ workflow cellranger_workflow {
         Int mkfastq_disk_space = 1500
         # Optional disk space needed for cell ranger count.
         Int count_disk_space = 500
+        # Optional disk space needed for cell ranger multi.
+        Int multi_disk_space = 2000
         # Optional disk space needed for cell ranger vdj.
         Int vdj_disk_space = 500
         # Optional disk space needed for cumulus_adt
@@ -485,7 +487,7 @@ workflow cellranger_workflow {
                         zones = zones,
                         num_cpu = num_cpu,
                         memory = memory,
-                        disk_space = count_disk_space,
+                        disk_space = multi_disk_space,
                         preemptible = preemptible,
                         backend = backend,
                         awsQueueArn = awsQueueArn


### PR DESCRIPTION
Cell ranger multi needs to use a dedicated parameter `multi_disk_space` which is larger for processing 10x Flex samples.