### PR TITLE
Update regarding GEM-X chemistries

### DIFF
--- a/docker/cellranger-arc/2.0.2.custom-max-cell/Dockerfile
+++ b/docker/cellranger-arc/2.0.2.custom-max-cell/Dockerfile
@@ -15,7 +15,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.9.4.zip" -o "aw
 RUN pip3 install --upgrade pip && \
     pip3 install pandas==1.5.2 && \
     pip3 install packaging==21.3 && \
-    pip3 install stratocumulus==0.1.7
+    pip3 install stratocumulus==0.2.4
 
 RUN mkdir /software
 ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
@@ -28,5 +28,5 @@ RUN apt-get -qq -y autoremove && \
     rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 
 RUN chmod a+rx /software/monitor_script.sh
-ENV PATH=/software:/software/cellranger-arc-2.0.2:$PATH
+ENV PATH=/software:/software/cellranger-arc-2.0.2:/usr/local/aws-cli/v2/current/bin:$PATH
 ENV TMPDIR=/tmp

--- a/docker/cellranger-arc/2.0.2/Dockerfile
+++ b/docker/cellranger-arc/2.0.2/Dockerfile
@@ -15,7 +15,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.7.11.zip" -o "a
 RUN pip3 install --upgrade pip && \
     pip3 install pandas==1.4.3 && \
     pip3 install packaging==21.3 && \
-    pip3 install stratocumulus==0.2.3
+    pip3 install stratocumulus==0.2.4
 
 RUN mkdir /software
 ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
@@ -27,5 +27,5 @@ RUN apt-get -qq -y autoremove && \
     rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 
 RUN chmod a+rx /software/monitor_script.sh
-ENV PATH=/software:/software/cellranger-arc-2.0.2:$PATH
+ENV PATH=/software:/software/cellranger-arc-2.0.2:/usr/local/aws-cli/v2/current/bin:$PATH
 ENV TMPDIR=/tmp

--- a/docker/cellranger-atac/2.1.0/Dockerfile
+++ b/docker/cellranger-atac/2.1.0/Dockerfile
@@ -17,7 +17,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python -m pip install --upgrade pip && \
     python -m pip install pandas==1.4.3 && \
     python -m pip install packaging==21.3 && \
-    python -m pip install stratocumulus==0.2.3
+    python -m pip install stratocumulus==0.2.4
 
 RUN mkdir /software
 ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
@@ -28,5 +28,5 @@ RUN apt-get -qq -y autoremove && \
     rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 
 RUN chmod a+rx /software/monitor_script.sh
-ENV PATH=/software:/software/cellranger-atac-2.1.0:$PATH
+ENV PATH=/software:/software/cellranger-atac-2.1.0:/usr/local/aws-cli/v2/current/bin:$PATH
 ENV TMPDIR=/tmp

--- a/docker/cellranger/8.0.0/Dockerfile
+++ b/docker/cellranger/8.0.0/Dockerfile
@@ -20,7 +20,7 @@ ENV PATH=/software/python/bin:$PATH
 RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install pandas==2.2.1 --no-cache-dir && \
     python -m pip install packaging==24.0 --no-cache-dir && \
-    python -m pip install stratocumulus==0.2.3 --no-cache-dir
+    python -m pip install stratocumulus==0.2.4 --no-cache-dir
 
 ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 ADD cellranger-8.0.0.tar.gz /software
@@ -30,5 +30,5 @@ RUN apt-get -qq -y autoremove && \
     rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 
 RUN chmod a+rx /software/monitor_script.sh
-ENV PATH=/software:/software/cellranger-8.0.0:$PATH
+ENV PATH=/software:/software/cellranger-8.0.0:/usr/local/aws-cli/v2/current/bin:$PATH
 ENV TMPDIR=/tmp

--- a/docker/cellranger/8.0.1/Dockerfile
+++ b/docker/cellranger/8.0.1/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:bookworm-slim
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y unzip rsync build-essential dpkg-dev curl gnupg procps python3 python3-pip python3-venv
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update -y && apt-get install -y google-cloud-cli=478.0.0-0
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.15.62.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm awscliv2.zip
+
+RUN python3 -m venv /software/python
+ENV PATH=/software/python/bin:$PATH
+
+RUN python -m pip install --upgrade pip --no-cache-dir && \
+    python -m pip install pandas==2.2.2 --no-cache-dir && \
+    python -m pip install packaging==24.0 --no-cache-dir && \
+    python -m pip install stratocumulus==0.2.4 --no-cache-dir
+
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
+ADD cellranger-8.0.1.tar.gz /software
+
+RUN apt-get -qq -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
+
+RUN chmod a+rx /software/monitor_script.sh
+ENV PATH=/software:/software/cellranger-8.0.1:/usr/local/aws-cli/v2/current/bin:$PATH
+ENV TMPDIR=/tmp

--- a/docker/cumulus_feature_barcoding/0.11.3/Dockerfile
+++ b/docker/cumulus_feature_barcoding/0.11.3/Dockerfile
@@ -34,7 +34,7 @@ RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install numpy==1.26.1 --no-cache-dir && \
     python -m pip install pandas==2.1.1 --no-cache-dir && \
     python -m pip install matplotlib==3.8.0 --no-cache-dir && \
-    python -m pip install stratocumulus==0.2.3 --no-cache-dir
+    python -m pip install stratocumulus==0.2.4 --no-cache-dir
 
 RUN tar -xzf /software/0.11.3.tar.gz -C /software && \
     cd /software/cumulus_feature_barcoding-0.11.3 && make clean && make all && cd ../.. && \
@@ -47,4 +47,4 @@ RUN apt-get -qq -y remove gnupg && \
 
 RUN chmod a+rx /software/*
 
-ENV PATH=/software:/software/cumulus_feature_barcoding-0.11.3:$PATH
+ENV PATH=/software:/software/cumulus_feature_barcoding-0.11.3:/usr/local/aws-cli/v2/current/bin:$PATH

--- a/docker/spaceranger/3.0.0/Dockerfile
+++ b/docker/spaceranger/3.0.0/Dockerfile
@@ -19,7 +19,7 @@ ENV PATH=/software/python/bin:$PATH
 RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install pandas==2.2.1 --no-cache-dir && \
     python -m pip install packaging==24.0 --no-cache-dir && \
-    python -m pip install stratocumulus==0.2.3 --no-cache-dir
+    python -m pip install stratocumulus==0.2.4 --no-cache-dir
 
 ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
 ADD spaceranger-3.0.0.tar.gz /software
@@ -29,5 +29,5 @@ RUN apt-get -qq -y autoremove && \
     rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
 
 RUN chmod a+rx /software/monitor_script.sh
-ENV PATH=/software:/software/spaceranger-3.0.0:$PATH
+ENV PATH=/software:/software/spaceranger-3.0.0:/usr/local/aws-cli/v2/current/bin:$PATH
 ENV TMPDIR=/tmp

--- a/docs/cellranger/feature_barcoding.rst
+++ b/docs/cellranger/feature_barcoding.rst
@@ -58,7 +58,9 @@ Sample sheet
 		* - **auto**
 		  - Default. This is an alias for Single Cell 3' v3 (SC3Pv3)
 		* - **threeprime**
-		  - This is another alias for Single Cell 3' v3
+		  - This is another alias for Single Cell 3' v3 (SC3Pv3)
+		* - **SC3Pv4**
+		  - Single Cell 3' v4. **Notice:** This is GEM-X chemistry, and only works for Cell Ranger v8.0.0+
 		* - **SC3Pv3**
 		  - Single Cell 3′ v3
 		* - **SC3Pv2**
@@ -67,8 +69,12 @@ Sample sheet
 		  - Single Cell 5′
 		* - **SC5P-PE**
 		  - Single Cell 5′ paired-end (both R1 and R2 are used for alignment)
+		* - **SC5P-PE-v3**
+		  - Single Cell 5' paired-end v3 (both R1 and R2 are used for alignment). **Notice:** This is GEM-X chemistry, and only works for Cell Ranger v8.0.0+
 		* - **SC5P-R2**
 		  - Single Cell 5′ R2-only (where only R2 is used for alignment)
+		* - **SC5P-R2-v3**
+		  - Single Cell 5' R2-only v3 (where only R2 is used for alignment). **Notice:** This is GEM-X chemistry, and only works for Cell Rangrer v8.0.0+
 		* - **multiome**
 		  - 10x Multiome barcodes
 

--- a/docs/cellranger/sc_multiomics.rst
+++ b/docs/cellranger/sc_multiomics.rst
@@ -152,8 +152,8 @@ For single-cell multiomics data, ``cellranger_workflow`` takes Illumina outputs 
 	  -
 	* - cellranger_version
 	  - cellranger version, could be: 8.0.0, 7.2.0, 7.1.0, 7.0.1, 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
-	  - "8.0.0"
-	  - "8.0.0"
+	  - "8.0.1"
+	  - "8.0.1"
 	* - cellranger_arc_version
 	  - cellranger-arc version, could be 2.0.2, 2.0.1, 2.0.0, 1.0.1, 1.0.0
 	  - "2.0.2"

--- a/docs/cellranger/sc_sn_rnaseq.rst
+++ b/docs/cellranger/sc_sn_rnaseq.rst
@@ -187,9 +187,9 @@ For sc/snRNA-seq data, ``cellranger_workflow`` takes Illumina outputs as input a
 		  - false
 		  - false
 		* - cellranger_version
-		  - cellranger version, could be: 8.0.0, 7.2.0, 7.1.0, 7.0.1, 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
-		  - "8.0.0"
-		  - "8.0.0"
+		  - cellranger version, could be: 8.0.1, 8.0.0, 7.2.0, 7.1.0, 7.0.1, 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
+		  - "8.0.1"
+		  - "8.0.1"
 		* - config_version
 		  - config docker version used for processing sample sheets, could be 0.3, 0.2, 0.1
 		  - "0.3"

--- a/docs/cellranger/sc_sn_rnaseq.rst
+++ b/docs/cellranger/sc_sn_rnaseq.rst
@@ -91,10 +91,16 @@ Sample sheet
 		  - Single Cell 3′ v2
 		* - **SC3Pv3**
 		  - Single Cell 3′ v3. You should set cellranger version input parameter to >= 3.0.2
+		* - **SC3Pv4**
+		  - Single Cell 3' v4. **Notice:** This is GEM-X chemistry, and only works for Cell Ranger v8.0.0+
 		* - **SC5P-PE**
 		  - Single Cell 5′ paired-end (both R1 and R2 are used for alignment)
+		* - **SC5P-PE-v3**
+		  - Single Cell 5' paired-end v3 (both R1 and R2 are used for alignment). **Notice:** This is GEM-X chemistry, and only works for Cell Ranger v8.0.0+
 		* - **SC5P-R2**
 		  - Single Cell 5′ R2-only (where only R2 is used for alignment)
+		* - **SC5P-R2-v3**
+		  - Single Cell 5' R2-only v3 (where only R2 is used for alignment). **Notice:** This is GEM-X chemistry, and only works for Cell Rangrer v8.0.0+
 
 #. *DataType* column.
 

--- a/docs/cellranger/sc_vdj.rst
+++ b/docs/cellranger/sc_vdj.rst
@@ -125,9 +125,9 @@ For scIR-seq data, ``cellranger_workflow`` takes Illumina outputs as input and r
 	  - "auto"
 	  - "auto"
 	* - cellranger_version
-	  - cellranger version, could be: 8.0.0, 7.2.0, 7.1.0, 7.0.1, 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
-	  - "8.0.0"
-	  - "8.0.0"
+	  - cellranger version, could be: 8.0.1, 8.0.0, 7.2.0, 7.1.0, 7.0.1, 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
+	  - "8.0.1"
+	  - "8.0.1"
 	* - docker_registry
 	  - Docker registry to use for cellranger_workflow. Options:
 

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -98,8 +98,8 @@ workflow cellranger_workflow {
         # Index TSV file
         File acronym_file = "gs://regev-lab/resources/cellranger/index.tsv"
 
-        # 8.8.0, 7.2.0, 7.1.0, 7.0.1, 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
-        String cellranger_version = "8.0.0"
+        # 8.0.1, 8.0.0, 7.2.0, 7.1.0, 7.0.1, 7.0.0, 6.1.2, 6.1.1, 6.0.2, 6.0.1, 6.0.0, 5.0.1, 5.0.0
+        String cellranger_version = "8.0.1"
         # 0.11.3, 0.11.2, 0.11.1, 0.11.0, 0.10.0, 0.9.0, 0.8.0, 0.7.0, 0.6.0, 0.5.0, 0.4.0, 0.3.0, 0.2.0
         String cumulus_feature_barcoding_version = "0.11.3"
         # 2.1.0, 2.0.0, 1.2.0, 1.1.0

--- a/workflows/cellranger/index.tsv
+++ b/workflows/cellranger/index.tsv
@@ -65,10 +65,13 @@ FRP_human_probe_v1	gs://regev-lab/resources/cellranger/Chromium_Human_Transcript
 FRP_human_probe_v1.0.1	gs://regev-lab/resources/cellranger/Chromium_Human_Transcriptome_Probe_Set_v1.0.1_GRCh38-2020-A.csv
 FRP_mouse_probe_v1	gs://regev-lab/resources/cellranger/Chromium_Mouse_Transcriptome_Probe_Set_v1.0_mm10-2020-A.csv
 FRP_mouse_probe_v1.0.1	gs://regev-lab/resources/cellranger/Chromium_Mouse_Transcriptome_Probe_Set_v1.0.1_mm10-2020-A.csv
+SC3Pv4	gs://regev-lab/resources/cellranger/3M-3pgex-may-2023.txt.gz
 SC3Pv3	gs://regev-lab/resources/cellranger/3M-february-2018.txt.gz
 SC3Pv2	gs://regev-lab/resources/cellranger/737K-august-2016.txt.gz
 fiveprime	gs://regev-lab/resources/cellranger/737K-august-2016.txt.gz
+SC5P-PE-v3	gs://regev-lab/resources/cellranger/3M-5pgex-jan-2023.txt.gz
 SC5P-PE	gs://regev-lab/resources/cellranger/737K-august-2016.txt.gz
+SC5P-R2-v3	gs://regev-lab/resources/cellranger/3M-5pgex-jan-2023.txt.gz
 SC5P-R2	gs://regev-lab/resources/cellranger/737K-august-2016.txt.gz
 multiome	gs://regev-lab/resources/cellranger/737K-arc-v1.txt.gz
 null_file	gs://regev-lab/resources/cellranger/null


### PR DESCRIPTION
* Add barcode whitelists for `SC3Pv4`, `SC5P-PE-v3` and `SC5P-R2-v3`, which are required by feature barcoding task
* Use Cell Ranger v8.0.1 by default
* Add `/usr/local/aws-cli/v2/current/bin` to `PATH` to resolve conflict with AWS Batch's auto-installed aws-cli