### PR TITLE
Fix workflow issue with cellranger-arc

### DIFF
--- a/docker/cellranger-arc/2.0.2.strato/Dockerfile
+++ b/docker/cellranger-arc/2.0.2.strato/Dockerfile
@@ -15,7 +15,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.7.11.zip" -o "a
 RUN pip3 install --upgrade pip && \
     pip3 install pandas==1.4.3 && \
     pip3 install packaging==21.3 && \
-    pip3 install stratocumulus==0.1.7
+    pip3 install stratocumulus==0.2.4
 
 RUN mkdir /software
 ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software

--- a/docs/cellranger/sc_multiomics.rst
+++ b/docs/cellranger/sc_multiomics.rst
@@ -155,9 +155,9 @@ For single-cell multiomics data, ``cellranger_workflow`` takes Illumina outputs 
 	  - "8.0.1"
 	  - "8.0.1"
 	* - cellranger_arc_version
-	  - cellranger-arc version, could be 2.0.2, 2.0.1, 2.0.0, 1.0.1, 1.0.0
-	  - "2.0.2"
-	  - "2.0.2"
+	  - cellranger-arc version, could be: ``2.0.2.strato`` (compatible with workflow v2.6.1+), ``2.0.2.custom-max-cell`` (with max_cell threshold set to 80,000), ``2.0.2`` (compatible with workflow v2.6.0 or earlier), ``2.0.1``, ``2.0.0``, ``1.0.1``, ``1.0.0``
+	  - "2.0.2.strato"
+	  - "2.0.2.strato"
 	* - docker_registry
 	  - Docker registry to use for cellranger_workflow. Options:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Yiming Yang, Joshua Gould and Bo Li'
 # The short X.Y version
 version = '2.6'
 # The full version, including alpha/beta/rc tags
-release = '2.6.1'
+release = '2.6.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/release_notes/version_2_6.rst
+++ b/docs/release_notes/version_2_6.rst
@@ -1,3 +1,8 @@
+2.6.2 :small:`June 19, 2024`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Solve the issue of Cellranger workflow with cellranger-arc. ``cellranger_arc_version`` default is now "2.0.2.strato" which is compatible with workflow v2.6.1 or later.
+
 2.6.1 :small:`May 8, 2024`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/workflows/cellbender/frp_utils.py
+++ b/workflows/cellbender/frp_utils.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pegasusio as io
+
+from pegasusio import MultimodalData, UnimodalData
+from typing import Union, Optional
+
+
+def filter_included_genes(
+    data: Union[MultimodalData, UnimodalData],
+    filt_features_tsv: pd.DataFrame,
+    output_file: Optional[str] = None,
+) -> None:
+    df_var = pd.read_csv(filt_features_tsv, sep='\t', header=None)
+    assert df_var[0].nunique() == 18082, "Filtered genes inconsistent!"
+
+    data._inplace_subset_var(data.var['featureid'].isin(df_var[0].values))
+    correct_gene_names(data)
+    if output_file:
+        io.write_output(data, output_file)
+
+def correct_gene_names(data):
+    rename_dict = {
+        "ENSG00000285053": "GGPS1-TBCE",
+        "ENSG00000284770": "TBCE",
+        "ENSG00000187522": "HSPA14",
+        "ENSG00000284024": "MSANTD7",
+        "ENSG00000269226": "TMSB15C",
+        "ENSG00000158427": "TMSB15B",
+    }
+    df_var = data.var.reset_index()
+    for gene_id, gene_name in rename_dict.items():
+        df_var.loc[df_var['featureid']==gene_id, 'featurekey'] = gene_name    
+    data.var = df_var.set_index('featurekey')

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -104,8 +104,8 @@ workflow cellranger_workflow {
         String cumulus_feature_barcoding_version = "0.11.3"
         # 2.1.0, 2.0.0, 1.2.0, 1.1.0
         String cellranger_atac_version = "2.1.0"
-        # 2.0.2, 2.0.1, 2.0.0, 1.0.1, 1.0.0
-        String cellranger_arc_version = "2.0.2"
+        # 2.0.2.strato, 2.0.2.custom-max-cell, 2.0.2, 2.0.1, 2.0.0, 1.0.1, 1.0.0
+        String cellranger_arc_version = "2.0.2.strato"
         # config version
         String config_version = "0.3"
 


### PR DESCRIPTION
For `cellranger-arc` docker images:
* `2.0.2` tag uses Stratocumulus v0.1.7, which requires `--backend` option, compatible with workflow v2.6.0 or earlier.
* `2.0.2.strato` tag uses Stratocumulus v0.2.4, which drops `--backend` option, compatible with workflow v2.6.1 or later.

In `cellranger_workflow.wdl`:
* `cellranger_arc_version` has default "2.0.2.strato".