### PR TITLE
Update Geomx workflows

### DIFF
--- a/docker/geomxngs_fastq_to_dcc/Dockerfile
+++ b/docker/geomxngs_fastq_to_dcc/Dockerfile
@@ -18,7 +18,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install pandas==1.2.5 --no-cache-dir && \
     python -m pip install packaging==21.0 --no-cache-dir && \
-    python -m pip install stratocumulus==0.1.3 --no-cache-dir
+    python -m pip install stratocumulus==0.2.4 --no-cache-dir
 
 
 RUN mkdir /software
@@ -35,4 +35,4 @@ RUN apt-get -qq -y remove git python3-pip \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* \
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
-ENV PATH=/software:/software/scripts/:/google-cloud-sdk/bin/:/var/GeoMxNGSPipeline:$PATH
+ENV PATH=/software:/software/scripts/:/google-cloud-sdk/bin/:/var/GeoMxNGSPipeline:/usr/local/aws-cli/v2/current/bin:$PATH

--- a/workflows/geomxng/geomxngs_dcc_to_count_matrix.wdl
+++ b/workflows/geomxng/geomxngs_dcc_to_count_matrix.wdl
@@ -40,9 +40,9 @@ workflow geomxngs_dcc_to_count_matrix {
     }
 
     output {
-        String count_matrix_h5ad = geomxngs_dcc_to_count_matrix_task.count_matrix_h5ad
-        String count_matrix_text = geomxngs_dcc_to_count_matrix_task.count_matrix_text
-        String count_matrix_metadata = geomxngs_dcc_to_count_matrix_task.count_matrix_metadata
+        File count_matrix_h5ad = geomxngs_dcc_to_count_matrix_task.count_matrix_h5ad
+        File count_matrix_text = geomxngs_dcc_to_count_matrix_task.count_matrix_text
+        File count_matrix_metadata = geomxngs_dcc_to_count_matrix_task.count_matrix_metadata
     }
 
     call geomxngs_dcc_to_count_matrix_task {
@@ -105,9 +105,9 @@ task geomxngs_dcc_to_count_matrix_task {
 
     output {
         File monitoring_log = "monitoring.log"
-        String count_matrix_h5ad = output_directory_trailing_slash + "counts.h5ad"
-        String count_matrix_text = output_directory_trailing_slash + "counts.txt"
-        String count_matrix_metadata = output_directory_trailing_slash + "metadata.txt"
+        File count_matrix_h5ad = output_directory_trailing_slash + "counts.h5ad"
+        File count_matrix_text = output_directory_trailing_slash + "counts.txt"
+        File count_matrix_metadata = output_directory_trailing_slash + "metadata.txt"
     }
 
     runtime {

--- a/workflows/geomxng/geomxngs_fastq_to_dcc.wdl
+++ b/workflows/geomxng/geomxngs_fastq_to_dcc.wdl
@@ -38,6 +38,7 @@ workflow geomxngs_fastq_to_dcc {
     output {
         String geomxngs_output = geomxngs_task.geomxngs_output
         String dcc_zip = geomxngs_task.dcc_zip
+        File local_dcc_zip = geomxngs_task.local_dcc_zip
     }
 
     call geomxngs_task {

--- a/workflows/geomxng/geomxngs_fastq_to_dcc.wdl
+++ b/workflows/geomxng/geomxngs_fastq_to_dcc.wdl
@@ -13,7 +13,6 @@ workflow geomxngs_fastq_to_dcc {
         String memory = "64GB"
         Int preemptible = 2
         String zones = "us-central1-a us-central1-b us-central1-c us-central1-f"
-        String backend = "gcp"
         String aws_queue_arn = ""
         Boolean delete_fastq_directory = false
     }
@@ -30,7 +29,6 @@ workflow geomxngs_fastq_to_dcc {
         memory : "Memory string"
         preemptible :"Number of preemptible tries"
         zones : "Google cloud zones"
-        backend : "Backend for computation (aws, gcp, or local)"
         aws_queue_arn : "The arn URI of the AWS job queue to be used (e.g. arn:aws:batch:us-east-1:xxxxx). Only works when backend is aws"
         delete_fastq_directory:"Whether to delete the input fastqs upon successful completion"
     }
@@ -55,7 +53,6 @@ workflow geomxngs_fastq_to_dcc {
             disk_space = disk_space,
             preemptible = preemptible,
             zones = zones,
-            backend = backend,
             aws_queue_arn = aws_queue_arn
     }
 
@@ -74,7 +71,6 @@ task geomxngs_task {
         String docker_registry
         String geomxngs_version
         String zones
-        String backend
         String aws_queue_arn
         Boolean delete_fastq_directory
     }
@@ -115,18 +111,17 @@ task geomxngs_task {
         # download and rename fastqs
         rename = '~{fastq_rename}'
         remote_fastq_dirs = '~{fastq_directory}'.split(',')
-        backend = '~{backend}'
         local_fastq_dirs = []
         if len(remote_fastq_dirs) == 1:
             local_fastq_dirs.append('fastqs')
-            check_call(['strato', 'sync', '--backend', backend, '-m', remote_fastq_dirs[0], 'fastqs/'])
+            check_call(['strato', 'sync', '-m', remote_fastq_dirs[0], 'fastqs/'])
         else:  # geomx pipeline only works with one directory of fastqs
             for i in range(len(remote_fastq_dirs)):
                 local_fastq_dir = 'fastqs-' + str(i + 1)
                 local_fastq_dirs.append(local_fastq_dir)
                 os.makedirs(local_fastq_dir, exist_ok=True)
                 check_call(
-                    ['strato', 'sync', '--backend', backend, '-m', remote_fastq_dirs[i], local_fastq_dir])
+                    ['strato', 'sync', '-m', remote_fastq_dirs[i], local_fastq_dir])
 
         if rename:
             df = pd.read_csv(rename, sep="\t", header=None, names=["original_name", "new_name"])
@@ -162,7 +157,7 @@ task geomxngs_task {
         CODE
 
         geomx_expect.exp
-        strato sync --backend ~{backend} -m results ~{output_directory_stripped}
+        strato sync -m results ~{output_directory_stripped}
 
         python <<CODE
         from subprocess import check_call
@@ -173,7 +168,7 @@ task geomxngs_task {
                 if not url.endswith("/"):
                     url += "/"
                 try:
-                    call_args = ["strato", "rm", "--backend", backend, "-m", "-r", url]
+                    call_args = ["strato", "rm", "-m", "-r", url]
                     check_call(call_args)
                     print("Deleted " + url)
                 except:

--- a/workflows/geomxng/geomxngs_fastq_to_dcc.wdl
+++ b/workflows/geomxng/geomxngs_fastq_to_dcc.wdl
@@ -156,6 +156,7 @@ task geomxngs_task {
                     os.rename(os.path.join(local_fastq_dir, f), dest)
         CODE
 
+        export TMPDIR="/tmp"
         geomx_expect.exp
         strato sync -m results ~{output_directory_stripped}
 


### PR DESCRIPTION
Following changes were made to the geomx workflows:

- Add aws-cli path to PATH
- Update stratocumulus to 0.2.4 & remove backend from strato options
- Modify the workflow output type from String to File
- Export TMPDIR in the task to fix issues with geomxngspipeline tool