### PR TITLE
update check_call function with shell=True and join call args

### DIFF
--- a/workflows/cellranger/cellranger_vdj.wdl
+++ b/workflows/cellranger/cellranger_vdj.wdl
@@ -127,7 +127,7 @@ task run_cellranger_vdj {
                     os.mkdir(target)
                 call_args = ['strato', 'cp', '-m', directory + '/~{sample_id}' + '_S*_L*_*_001.fastq.gz' , target]
                 print(' '.join(call_args))
-                check_call(call_args)
+                check_call(' '.join(call_args),shell=True)
             fastqs.append(target)
 
         call_args = ['cellranger', 'vdj', '--chain=~{chain}', '--id=results', '--reference=ref_dir', '--fastqs=' + ','.join(fastqs), '--sample=~{sample_id}', '--jobmode=local']


### PR DESCRIPTION
This fix is specifically for backend=local in check_call function.
- joining the call arguments
- set "shell=True"