### PR TITLE
Set `--localmem` for cellranger and spaceranger workflows

### DIFF
--- a/workflows/cellranger/cellranger_count.wdl
+++ b/workflows/cellranger/cellranger_count.wdl
@@ -223,7 +223,8 @@ task run_cellranger_count {
                     check_call(call_args)
                 fastqs_dirs.append(target)
 
-        call_args = ['cellranger', 'count', '--id=results', '--transcriptome=genome_dir', '--chemistry=~{chemistry}', '--jobmode=local']
+        mem_size = re.findall(r"\d+", "~{memory}")[0]
+        call_args = ['cellranger', 'count', '--id=results', '--transcriptome=genome_dir', '--chemistry=~{chemistry}', '--jobmode=local', '--localmem='+mem_size]
 
         if samples is None: # not Feature Barcode
             call_args.extend(['--sample=~{sample_id}', '--fastqs=' + ','.join(fastqs_dirs)])

--- a/workflows/cellranger/cellranger_multi.wdl
+++ b/workflows/cellranger/cellranger_multi.wdl
@@ -272,8 +272,8 @@ task run_cellranger_multi {
             if (not has_cmo) and (not has_frp):
                 raise Exception("Cannot locate CMO or FRP sample file!")
 
-
-        call_args = ['cellranger', 'multi', '--id=results', '--csv=multi.csv', '--jobmode=local']
+        mem_size = re.findall(r"\d+", "~{memory}")[0]
+        call_args = ['cellranger', 'multi', '--id=results', '--csv=multi.csv', '--jobmode=local', '--localmem='+mem_size]
         print(' '.join(call_args))
         check_call(call_args)
         CODE

--- a/workflows/cellranger/cellranger_vdj.wdl
+++ b/workflows/cellranger/cellranger_vdj.wdl
@@ -130,7 +130,8 @@ task run_cellranger_vdj {
                 check_call(call_args)
             fastqs.append(target)
 
-        call_args = ['cellranger', 'vdj', '--chain=~{chain}', '--id=results', '--reference=ref_dir', '--fastqs=' + ','.join(fastqs), '--sample=~{sample_id}', '--jobmode=local']
+        mem_size = re.findall(r"\d+", "~{memory}")[0]
+        call_args = ['cellranger', 'vdj', '--chain=~{chain}', '--id=results', '--reference=ref_dir', '--fastqs=' + ','.join(fastqs), '--sample=~{sample_id}', '--jobmode=local', '--localmem='+mem_size]
         if '~{denovo}' != 'false':
             call_args.append('--denovo')
         print(' '.join(call_args))

--- a/workflows/spaceranger/spaceranger_count.wdl
+++ b/workflows/spaceranger/spaceranger_count.wdl
@@ -211,6 +211,9 @@ task run_spaceranger_count {
 
         call_args = ['spaceranger', 'count', '--id=results', '--transcriptome=genome_dir', '--fastqs=' + ','.join(fastqs), '--sample=~{sample_id}', '--jobmode=local']
 
+        localmem = "".join(filter(str.isdigit, "~{memory}"))
+        call_args.append("--localmem=" + localmem)
+
         def not_null(input_file):
             return (input_file != '') and (os.path.basename(input_file) != 'null')
 


### PR DESCRIPTION
Enforce cellranger and spaceranger run with fixed memory with `--localmem` option.

This is to avoid memory preempt across tasks running on the same VM instance under AWS/GCP Batch.