### PR TITLE
Upgrade to cumulus_feature_barcoding v2.0.0

### DIFF
--- a/docker/cumulus_feature_barcoding/2.0.0/Dockerfile
+++ b/docker/cumulus_feature_barcoding/2.0.0/Dockerfile
@@ -1,0 +1,53 @@
+FROM debian:bookworm-slim
+SHELL ["/bin/bash", "-c"]
+
+ADD https://github.com/lilab-bcb/cumulus_feature_barcoding/archive/refs/tags/2.0.0.tar.gz /software/
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software/
+
+RUN apt-get -qq update && \
+    apt-get -qq -y install --no-install-recommends \
+        rsync \
+        curl \
+        unzip \
+        gnupg \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        build-essential \
+        libisal2 libisal-dev \
+        libdeflate0 libdeflate-dev \
+        libhdf5-dev
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update -y && apt-get install -y google-cloud-cli=521.0.0-0
+
+ENV CLOUDSDK_PYTHON=/usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python
+ENV CLOUDSDK_GSUTIL_PYTHON=/usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.27.12.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm awscliv2.zip
+
+RUN python3 -m venv /software/python
+ENV PATH=/software/python/bin:$PATH
+
+RUN python -m pip install --upgrade pip --no-cache-dir && \
+    python -m pip install stratocumulus==0.3.0 --no-cache-dir
+
+RUN tar -xzf /software/2.0.0.tar.gz -C /software && \
+    cd /software/cumulus_feature_barcoding-2.0.0 && make clean && make all && cd ../.. && \
+    rm -f /software/2.0.0.tar.gz
+
+ADD barcode_list /software/barcode_list
+
+RUN apt-get -qq -y remove gnupg && \
+    apt-get -qq -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
+
+RUN chmod a+rx /software/*
+
+ENV PATH=/software:/software/cumulus_feature_barcoding-2.0.0:/usr/local/aws-cli/v2/current/bin:$PATH

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -71,7 +71,7 @@ workflow cellranger_workflow {
 
         # 9.0.1, 8.0.1, 7.2.0
         String cellranger_version = "9.0.1"
-        String cumulus_feature_barcoding_version = "1.0.0"
+        String cumulus_feature_barcoding_version = "2.0.0"
         # 2.1.0, 2.0.0
         String cellranger_atac_version = "2.1.0"
         # 2.0.2.strato, 2.0.2.custom-max-cell, 2.0.2, 2.0.1, 2.0.0
@@ -236,12 +236,13 @@ workflow cellranger_workflow {
                     input_fastqs_directories = generate_count_config.sample2dir[sample_id],
                     output_directory = output_directory_stripped,
                     chemistry = generate_count_config.sample2chemistry[sample_id],
+                    genome = generate_count_config.sample2ref[sample_id],
                     data_type = generate_count_config.sample2datatype[sample_id],
                     feature_barcode_file = generate_count_config.sample2aux[sample_id],
                     crispr_barcode_pos = crispr_barcode_pos,
                     scaffold_sequence = scaffold_sequence,
                     max_mismatch = max_mismatch,
-                    min_read_ratio = min_read_ratio,
+                    read_ratio_cutoff = read_ratio_cutoff,
                     cumulus_feature_barcoding_version = cumulus_feature_barcoding_version,
                     docker_registry = docker_registry_stripped,
                     zones = zones,

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -48,7 +48,7 @@ workflow cellranger_workflow {
         # maximum hamming distance in feature barcodes (change default to 2)
         Int max_mismatch = 2
         # minimum read count ratio (non-inclusive) to justify a feature given a cell barcode and feature combination, only used for data type crispr
-        Float min_read_ratio = 0.1
+        Float read_ratio_cutoff = 0.1
 
         # For atac
 

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -516,11 +516,10 @@ task generate_count_config {
                 dirs = df_local['Flowcell'].values
 
                 reference = 'null'
-                if datatype in ['rna', 'vdj', 'vdj_t', 'vdj_b', 'vdj_t_gd', 'atac', 'frp']:
-                    if df_local['Reference'].unique().size > 1:
-                        print("Detected multiple references for sample " + sample_id + "!", file = sys.stderr)
-                        sys.exit(1)
-                    reference = df_local['Reference'].iat[0]
+                if df_local['Reference'].unique().size > 1:
+                    print("Detected multiple references for sample " + sample_id + "!", file = sys.stderr)
+                    sys.exit(1)
+                reference = df_local['Reference'].iat[0]
 
                 probe_set_file = '~{null_file}'
                 if datatype == 'frp':

--- a/workflows/cumulus/cumulus_adt.wdl
+++ b/workflows/cumulus/cumulus_adt.wdl
@@ -127,13 +127,13 @@ task run_generate_count_matrix_ADTs {
                 call_args = ['strato', 'exists', directory + '/~{sample_id}/']
                 print(' '.join(call_args))
                 check_call(call_args, stderr=STDOUT, stdout=DEVNULL)
-                call_args = ['strato', 'sync', '-m', directory + '/~{sample_id}', target]
+                call_args = ['strato', 'sync', directory + '/~{sample_id}', target]
                 print(' '.join(call_args))
                 check_call(call_args)
             except CalledProcessError:
                 if not os.path.exists(target):
                     os.mkdir(target)
-                call_args = ['strato', 'cp', '-m', directory + '/~{sample_id}' + '_S*_L*_*_001.fastq.gz' , target]
+                call_args = ['strato', 'cp', directory + '/~{sample_id}' + '_S*_L*_*_001.fastq.gz' , target]
                 print(' '.join(call_args))
                 check_call(call_args)
             fastqs.append(target)
@@ -154,7 +154,7 @@ task run_generate_count_matrix_ADTs {
 
         CODE
 
-        strato cp -m "~{sample_id}".*h5 "~{sample_id}".report.txt "~{output_directory}/~{sample_id}/"
+        strato cp "~{sample_id}".*h5 "~{sample_id}".report.txt "~{output_directory}/~{sample_id}/"
     }
 
     output {


### PR DESCRIPTION
Cellranger workflow:
* Rename `min_read_ratio` to `read_ratio_cutoff`
* Antibody type samples now take `Reference` column values
* Upgrade `cumulus_feature_barcoding_version` default to `2.0.0`