### PR TITLE
fix(DemuxEM.wdl): Added environment variables to use currect number of threads to use by sklearn and numpy.

### DIFF
--- a/workflows/demultiplexing/demuxEM.wdl
+++ b/workflows/demultiplexing/demuxEM.wdl
@@ -108,6 +108,10 @@ task run_demuxEM {
         set -e
         export TMPDIR=/tmp
         export BACKEND=~{backend}
+        export OMP_NUM_THREADS=~{num_cpu}
+        export MKL_NUM_THREADS=~{num_cpu}
+        export OPENBLAS_NUM_THREADS=~{num_cpu}
+
         monitor_script.sh > monitoring.log &
 
         python <<CODE


### PR DESCRIPTION
Hello,

We had an issue with demuxEM workflow when running them in parallel on 96 cpu cores machines, they would randomly fail with segfault.

Basically, the issue is: while running in docker container, the script still was sees all 96 cores, so it defaults to running 96 cores for openblas used in sklearn/numpy. And while docker limits processor usage, it leads to go over linux's mmap limit and then leads to crash.

