### PR TITLE
Bug fix in Cellranger config step

### DIFF
--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -570,6 +570,8 @@ task generate_count_config {
                                 link2ref[link].add(reference)
                         if (probe_set_file != '~{null_file}') or (len(link2probeset[link]) == 0):
                             link2probeset[link].add(probe_set_file)
+                            if len(link2probeset[link]) > 1:
+                                link2probeset[link] = [f for f in link2probeset[link] if f != '~{null_file}']    # Clear the null placeholder if exists.
                         continue
 
                 datatype2fo[datatype].write(sample_id + '\n')


### PR DESCRIPTION
If a sample sheet has the following order of samples:
```
Link,Sample,Reference,DataType,...
link1,sample1,GRCh38-2020-A,citeseq,...
link1,sample2,GRCh38-2020-A,frp,...
```
The resulting `sample2probeset` would have 2 files (one correct probe set file, one null file) for `link1`.

This is because when adding the probe set for the Flex `sample2`, there is no way to clear the placeholder which was initially added by `sample2` of CITE-Seq type.