### PR TITLE
Add GEX+VDJ linked sample routing to cellranger multi pipeline

### DIFF
--- a/workflows/cellranger/cellranger_multi.wdl
+++ b/workflows/cellranger/cellranger_multi.wdl
@@ -170,6 +170,7 @@ task run_cellranger_multi {
         has_hto = False
         has_cmo = False
         has_flex = False
+        has_vdj = False
         for dtype, aux in zip(data_types, auxs):
             if dtype == 'rna':  # OCM, HTO, and CMO cases
                 rna_file.add(aux)
@@ -179,8 +180,9 @@ task run_cellranger_multi {
             elif dtype == 'frp':
                 flex_file.add(aux)
                 has_flex = True
-            elif dtype in ['vdj', 'vdj_t_gd']:
+            elif dtype in ['vdj', 'vdj_t', 'vdj_b', 'vdj_t_gd']:
                 vdj_file.add(aux)
+                has_vdj = True
             else:  # hashing, citeseq, adt
                 feature_file.add(aux)
                 if dtype in ['hashing', 'adt']:
@@ -341,7 +343,7 @@ task run_cellranger_multi {
                     with open(flex_file, 'r') as fin:
                         write_csv_wise(['sample_id', 'probe_barcode_ids', 'description'], fin, fout)
 
-            if (not has_ocm) and (not has_hto) and (not has_cmo) and (not has_flex):
+            if (not has_ocm) and (not has_hto) and (not has_cmo) and (not has_flex) and (not has_vdj):
                 raise Exception("Cannot locate OCM, HTO, CMO, or Flex sample file!")
 
         mem_size = re.findall(r"\d+", "~{memory}")[0]

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -666,7 +666,19 @@ task generate_count_config {
                             no_aux = False
                             continue
 
+                    # VDJ + GEX case — route to cellranger multi
+                    vdj_types = set(['vdj', 'vdj_t', 'vdj_b', 'vdj_t_gd'])
+                    if 'rna' in multiomics[link_id] and multiomics[link_id] & vdj_types:
+                        if not multiomics[link_id].issubset(set(['rna', 'vdj', 'vdj_t', 'vdj_b', 'vdj_t_gd', 'citeseq', 'hashing', 'adt', 'crispr'])):
+                            print("Unsupported data type combination for GEX+VDJ multi run!", file=sys.stderr)
+                            sys.exit(1)
+                        fol_multi.write(link_id + '\n')
+                        fom_s2aux.write(link_id + '\t' + ','.join(link2aux[link_id]) + '\n')
+                        no_aux = False
+                        continue
+
                     # FBC case
+                    if not multiomics[link_id].issubset(set(['rna', 'crispr', 'citeseq'])):# FBC case
                     if not multiomics[link_id].issubset(set(['rna', 'crispr', 'citeseq'])):
                         print("CellRanger count only works with RNA/CRISPR/CITESEQ data! Link '" + link_id + "' contains " + ', '.join(list(multiomics[link_id])) + '.', file = sys.stderr)
                         sys.exit(1)


### PR DESCRIPTION
Fixes #464

GEX + VDJ linked samples did not trigger cellranger multi as expected,
instead falling through to the FBC path and erroring out. This is a 
gap in the routing logic since Cell Ranger natively supports GEX + VDJ 
as a valid multi combination without requiring any additional library 
types.

Changes:
- cellranger_workflow.wdl: Add routing branch that catches linked 
  groups containing rna + any VDJ type (vdj, vdj_t, vdj_b, vdj_t_gd) 
  and routes them to link_multi_ids
- cellranger_multi.wdl: Add has_vdj flag and expand VDJ dtype 
  detection to include vdj_t and vdj_b. Fix the sample file validation 
  to allow pure GEX+VDJ runs through without requiring an OCM/HTO/CMO 
  or Flex sample file