### PR TITLE
Add hashing and adt to allowed DataTypes in linked group routing

### DIFF
--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -646,7 +646,7 @@ task generate_count_config {
                     if 'rna' not in multiomics[link_id]:
                         print("CellRanger multi expect RNA modality!", file = sys.stderr)
                         sys.exit(1)
-                    if not multiomics[link_id].issubset(set(['rna', 'cmo', 'crispr', 'citeseq'])):
+                    if not multiomics[link_id].issubset(set(['rna', 'cmo', 'crispr', 'citeseq', 'hashing', 'adt'])):
                         print("CellRanger multi only works with RNA/CMO/CRISPR/CITESEQ data! Link '" + link_id + "' contains " + ', '.join(list(multiomics[link_id])) + '.', file = sys.stderr)
                         sys.exit(1)
                     fol_multi.write(link_id + '\n')
@@ -667,7 +667,7 @@ task generate_count_config {
                             continue
 
                     # FBC case
-                    if not multiomics[link_id].issubset(set(['rna', 'crispr', 'citeseq'])):
+                    if not multiomics[link_id].issubset(set(['rna', 'crispr', 'citeseq', 'hashing', 'adt'])):
                         print("CellRanger count only works with RNA/CRISPR/CITESEQ data! Link '" + link_id + "' contains " + ', '.join(list(multiomics[link_id])) + '.', file = sys.stderr)
                         sys.exit(1)
                     fol_link_fbc.write(link_id + '\n')


### PR DESCRIPTION
Fixes #465

hashing and adt DataTypes are recognized and valid in the workflow 
but cause an error when used in linked sample groups. This is because 
both the CMO multi path check and the FBC path check have explicit 
allowed DataType sets that include citeseq but omit hashing and adt, 
despite all three being functionally equivalent in this context.

This fix adds hashing and adt to both allowed sets so linked groups 
containing these DataTypes route correctly.