### PR TITLE
New release related to Cellranger

### DIFF
--- a/docker/cellranger/10.1.0/Dockerfile
+++ b/docker/cellranger/10.1.0/Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:trixie-slim
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y unzip rsync build-essential dpkg-dev curl gnupg procps python3 python3-pip python3-venv
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor | tee /usr/share/keyrings/cloud.google.gpg > /dev/null && \
+    apt-get update -y && apt-get install -y google-cloud-cli=578.0.0-0
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.36.14.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm awscliv2.zip
+
+RUN python3 -m venv /software/python
+ENV PATH=/software/python/bin:$PATH
+
+RUN python -m pip install --upgrade pip && \
+    python -m pip install pandas==3.0.5 && \
+    python -m pip install packaging==26.2 && \
+    python -m pip install stratocumulus==0.3.0
+
+ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software
+ADD cellranger-10.1.0.tar.gz /software
+
+# Avoid sending telemetry data to 10x Genomics
+ENV TENX_DISABLE_TELEMETRY=1
+
+RUN apt-get -qq -y autoremove && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/log/dpkg.log
+
+RUN chmod a+rx /software/monitor_script.sh
+ENV PATH=/software:/software/cellranger-10.1.0:/usr/local/aws-cli/v2/current/bin:$PATH
+ENV TMPDIR=/tmp
+
+ENV CLOUDSDK_PYTHON=/usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python
+ENV CLOUDSDK_GSUTIL_PYTHON=/usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python

--- a/docker/cumulus_feature_barcoding/2.1.0/Dockerfile
+++ b/docker/cumulus_feature_barcoding/2.1.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:trixie-slim
 SHELL ["/bin/bash", "-c"]
 
-ADD https://github.com/lilab-bcb/cumulus_feature_barcoding/archive/refs/tags/2.1.0rc1.tar.gz /software/
+ADD https://github.com/lilab-bcb/cumulus_feature_barcoding/archive/refs/tags/2.1.0.tar.gz /software/
 ADD https://raw.githubusercontent.com/lilab-bcb/cumulus/master/docker/monitor_script.sh /software/
 
 RUN apt-get -qq update && \
@@ -21,12 +21,12 @@ RUN apt-get -qq update && \
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor | tee /usr/share/keyrings/cloud.google.gpg > /dev/null && \
-    apt-get update -y && apt-get install -y google-cloud-cli=565.0.0-0
+    apt-get update -y && apt-get install -y google-cloud-cli=579.0.0-0
 
 ENV CLOUDSDK_PYTHON=/usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python
 ENV CLOUDSDK_GSUTIL_PYTHON=/usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.34.31.zip" -o "awscliv2.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.36.16.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm awscliv2.zip
@@ -37,9 +37,9 @@ ENV PATH=/software/python/bin:$PATH
 RUN python -m pip install --upgrade pip --no-cache-dir && \
     python -m pip install stratocumulus==0.3.0 --no-cache-dir
 
-RUN tar -xzf /software/2.1.0rc1.tar.gz -C /software && \
-    cd /software/cumulus_feature_barcoding-2.1.0rc1 && make clean && make all && cd ../.. && \
-    rm -f /software/2.1.0rc1.tar.gz
+RUN tar -xzf /software/2.1.0.tar.gz -C /software && \
+    cd /software/cumulus_feature_barcoding-2.1.0 && make clean && make all && cd ../.. && \
+    rm -f /software/2.1.0.tar.gz
 
 ADD barcode_list /software/barcode_list
 
@@ -50,4 +50,4 @@ RUN apt-get -qq -y remove gnupg && \
 
 RUN chmod a+rx /software/*
 
-ENV PATH=/software:/software/cumulus_feature_barcoding-2.1.0rc1:/usr/local/aws-cli/v2/current/bin:$PATH
+ENV PATH=/software:/software/cumulus_feature_barcoding-2.1.0:/usr/local/aws-cli/v2/current/bin:$PATH

--- a/docs/cellranger/multi.rst
+++ b/docs/cellranger/multi.rst
@@ -80,7 +80,7 @@ This section covers preparing the sample sheet for Flex_ (previously named *Fixe
   Flex uses probes that target protein-coding genes in the human or mouse transcriptome. It's automatically determined by the genome reference and Flex chemistry version specified by users for the scRNA-Seq sample by following the table below:
 
     .. list-table::
-        :widths: 5 5 5 5
+        :widths: 5 5 5 5 5
         :header-rows: 1
 
         * - Genome Reference

--- a/docs/cellranger/multi.rst
+++ b/docs/cellranger/multi.rst
@@ -84,8 +84,8 @@ This section covers preparing the sample sheet for Flex_ (previously named *Fixe
         :header-rows: 1
 
         * - Genome Reference
-          - Flex chemistry version
           - Species
+          - Flex chemistry version
           - Probe Set
           - Cell Ranger version
         * - GRCh38-2024-A

--- a/docs/cellranger/multi.rst
+++ b/docs/cellranger/multi.rst
@@ -85,32 +85,44 @@ This section covers preparing the sample sheet for Flex_ (previously named *Fixe
 
         * - Genome Reference
           - Flex chemistry version
+          - Species
           - Probe Set
           - Cell Ranger version
         * - GRCh38-2024-A
+          - Human
           - v2
           - `Flex_human_probe_v2.0`_
           - v10.0+
         * - GRCh38-2024-A
+          - Human
           - v1
           - `Flex_human_probe_v1.1`_
           - v9.0+
         * - GRCh38-2020-A
+          - Human
           - v1
           - `Flex_human_probe_v1.0.1`_
           - v7.1+
         * - GRCm39-2024-A
+          - Mouse
           - v2
           - `Flex_mouse_probe_v2.0`_
           - v10.0+
         * - GRCm39-2024-A
+          - Mouse
           - v1
           - `Flex_mouse_probe_v1.1`_
           - v9.0+
         * - mm10-2020-A
+          - Mouse
           - v1
           - `Flex_mouse_probe_v1.0.1`_
           - v7.1+
+        * - mRatBN7.2-2024-A
+          - Rat
+          - v2
+          - `Flex_rat_probe_v2.0`_
+          - v10.1+
 
   See `Flex probe sets overview`_ for details on these probe sets.
 
@@ -434,9 +446,9 @@ All the sample multiplexing assays share the same workflow input settings. ``cel
       - false
       - false
     * - cellranger_version
-      - Cell Ranger version to use. Available versions: 10.0.0, 9.0.1, 8.0.1, 7.2.0.
-      - "10.0.0"
-      - "10.0.0"
+      - Cell Ranger version to use. Available versions: 10.1.0, 10.0.0, 9.0.1, 8.0.1, 7.2.0.
+      - "10.1.0"
+      - "10.1.0"
     * - docker_registry
       - Docker registry to use for cellranger_workflow. Options:
 
@@ -516,3 +528,4 @@ All the sample multiplexing assays share the same workflow output structure. See
 .. _Flex_mouse_probe_v2.0: https://www.10xgenomics.com/support/flex-gene-expression/documentation/steps/probe-sets/chromium-frp-mouse-transcriptome-probe-set-2-0
 .. _Flex_mouse_probe_v1.1: https://www.10xgenomics.com/support/flex-gene-expression/documentation/steps/probe-sets/chromium-frp-mouse-transcriptome-probe-set-1-1
 .. _Flex_mouse_probe_v1.0.1: https://www.10xgenomics.com/support/flex-gene-expression/documentation/steps/probe-sets/chromium-frp-mouse-transcriptome-probe-set
+.. _Flex_rat_probe_v2.0: https://www.10xgenomics.com/support/flex-gene-expression/documentation/steps/probe-sets/chromium-flex-rat-transcriptome-probe-set-2-0

--- a/docs/cellranger/sc_sn_rnaseq.rst
+++ b/docs/cellranger/sc_sn_rnaseq.rst
@@ -116,9 +116,9 @@ For sc/snRNA-seq data, ``cellranger_workflow`` takes sequencing reads as input (
 		  - false
 		  - false
 		* - cellranger_version
-		  - cellranger version, could be: 10.0.0, 9.0.1, 8.0.1, 7.2.0
-		  - "10.0.0"
-		  - "10.0.0"
+		  - cellranger version, could be: 10.1.0, 10.0.0, 9.0.1, 8.0.1, 7.2.0
+		  - "10.1.0"
+		  - "10.1.0"
 		* - docker_registry
 		  - Docker registry to use for cellranger_workflow. Options:
 

--- a/docs/cellranger/sc_vdj.rst
+++ b/docs/cellranger/sc_vdj.rst
@@ -82,9 +82,9 @@ For scIR-seq data, ``cellranger_workflow`` takes sequencing reads as input (FAST
 	  - false
 	  - false
 	* - cellranger_version
-	  - cellranger version, could be: 10.0.0, 9.0.1, 8.0.1, 7.2.0
-	  - "10.0.0"
-	  - "10.0.0"
+	  - cellranger version, could be: 10.1.0, 10.0.0, 9.0.1, 8.0.1, 7.2.0
+	  - "10.1.0"
+	  - "10.1.0"
 	* - docker_registry
 	  - Docker registry to use for cellranger_workflow. Options:
 

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -71,7 +71,8 @@ workflow cellranger_workflow {
 
         # 10.1.0, 10.0.0, 9.0.1, 8.0.1, 7.2.0
         String cellranger_version = "10.1.0"
-        String cumulus_feature_barcoding_version = "2.0.0"
+        # 2.1.0, 2.0.0
+        String cumulus_feature_barcoding_version = "2.1.0"
         # 2.2.0, 2.1.0, 2.0.0
         String cellranger_atac_version = "2.2.0"
         # 2.2.0, 2.1.0, 2.0.2.strato, 2.0.2.custom-max-cell, 2.0.2, 2.0.1, 2.0.0

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -69,8 +69,8 @@ workflow cellranger_workflow {
         # Index TSV file
         File acronym_file = "gs://cumulus-ref/resources/cellranger/index.tsv"
 
-        # 10.0.0, 9.0.1, 8.0.1, 7.2.0
-        String cellranger_version = "10.0.0"
+        # 10.1.0, 10.0.1, 10.0.0, 9.0.1, 8.0.1, 7.2.0
+        String cellranger_version = "10.1.0"
         String cumulus_feature_barcoding_version = "2.0.0"
         # 2.2.0, 2.1.0, 2.0.0
         String cellranger_atac_version = "2.2.0"

--- a/workflows/cellranger/cellranger_workflow.wdl
+++ b/workflows/cellranger/cellranger_workflow.wdl
@@ -69,7 +69,7 @@ workflow cellranger_workflow {
         # Index TSV file
         File acronym_file = "gs://cumulus-ref/resources/cellranger/index.tsv"
 
-        # 10.1.0, 10.0.1, 10.0.0, 9.0.1, 8.0.1, 7.2.0
+        # 10.1.0, 10.0.0, 9.0.1, 8.0.1, 7.2.0
         String cellranger_version = "10.1.0"
         String cumulus_feature_barcoding_version = "2.0.0"
         # 2.2.0, 2.1.0, 2.0.0

--- a/workflows/cellranger/flex_probesets.tsv
+++ b/workflows/cellranger/flex_probesets.tsv
@@ -4,3 +4,4 @@ GRCh38-2024-A	gs://cumulus-ref/resources/cellranger/Chromium_Human_Transcriptome
 GRCm39-2024-A	gs://cumulus-ref/resources/cellranger/Chromium_Mouse_Transcriptome_Probe_Set_v1.1.1_GRCm39-2024-A.csv
 GRCh38-2020-A	gs://cumulus-ref/resources/cellranger/Chromium_Human_Transcriptome_Probe_Set_v1.0.1_GRCh38-2020-A.csv
 mm10-2020-A	gs://cumulus-ref/resources/cellranger/Chromium_Mouse_Transcriptome_Probe_Set_v1.0.1_mm10-2020-A.csv
+mRatBN7.2-2024-A	gs://cumulus-ref/resources/cellranger/Chromium_Rat_Transcriptome_Probe_Set_v2.0.0_mRatBN7-2-2024-A.csv


### PR DESCRIPTION
* Use _cumulus_feature_barcoding_ v2.1.0 for improved memory efficiency.
* Upgrade _cellranger_version_ default to `10.1.0`.
* Upgrade _cellranger_arc_version_ default to `2.2.0`.
* Add Rat probeset for Flex data processing.